### PR TITLE
Fix __update_image_lookup in chn_sbs.py

### DIFF
--- a/plugin.video.retrospect/channels/channel.se/sbs/chn_sbs.py
+++ b/plugin.video.retrospect/channels/channel.se/sbs/chn_sbs.py
@@ -604,7 +604,7 @@ class Channel(chn_class.Channel):
 
     # noinspection PyTypeChecker
     def __update_image_lookup(self, json_data):
-        images = filter(lambda a: a["type"] == "image" and a["attributes"]["kind"] == "default", json_data.get_value("included"))
+        images = filter(lambda a: a["type"] == "image" and a["attributes"]["kind"] != "poster", json_data.get_value("included"))
         images = {str(image["id"]): image["attributes"]["src"] for image in images}
 
         shows = filter(lambda a: a["type"] == "show", json_data.get_value("included"))

--- a/plugin.video.retrospect/channels/channel.se/sbs/chn_sbs.py
+++ b/plugin.video.retrospect/channels/channel.se/sbs/chn_sbs.py
@@ -604,7 +604,7 @@ class Channel(chn_class.Channel):
 
     # noinspection PyTypeChecker
     def __update_image_lookup(self, json_data):
-        images = filter(lambda a: a["type"] == "image", json_data.get_value("included"))
+        images = filter(lambda a: a["type"] == "image" and a["attributes"]["kind"] == "default", json_data.get_value("included"))
         images = {str(image["id"]): image["attributes"]["src"] for image in images}
 
         shows = filter(lambda a: a["type"] == "show", json_data.get_value("included"))


### PR DESCRIPTION
On
Raspberry PI 3 with OSMC
Retrospect 5.1.4

When I opened "Kanal 5" (Sweden) I got a toaster that said something along the lines of "Could not retrive list". In the log I got: KeyError: "src" in /plugin.video.retrospect/channels/channel.se/sbs/chn_sbs.py:608/618 (without/with @basrieter's patch from https://github.com/retrospect-addon/plugin.video.retrospect/issues/1275)

When I manually check the fetched JSON there's an entry with type "image" but without "attributes"->"src" (Its "kind" is different -> "poster"). This explains the KeyError: "src"... it's missing "src" in "attributes"...

__update_image_lookup should pass a test with json_data:

```
{
 "includes": [
{
    "attributes" : {
      "default" : true,
      "kind" : "poster"
    },
    "id" : "667840-show-12346",
    "type" : "image"
  }
 ]
}
```