### PR TITLE
Replace `wait-for-playback` code with custom Kodi player

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@ Besides this we fixed the following channels: L1, TV4Play.se and Stievie.be.
 [B]Framework related[/B]
 * Fixed: Issue where empty subtitle files could be stored after download (Fixes #1338)
 * Removed: The url no longer contains the full pickle of an item. Instead, it only contains a reference to an item that is located on disk (Fixes #1261)
+* Changed: use child class of `xbmc.Player` to detect playback start and stop
 
 [B]GUI/Settings/Language related[/B]
 -

--- a/resources/lib/__init__.py
+++ b/resources/lib/__init__.py
@@ -4,4 +4,4 @@ __all__ = ["addon", "addonsettings", "backtothefuture", "channelinfo", "chn_clas
            "contextmenu", "envcontroller", "environments", "favourites", "initializer", "locker",
            "logger", "mediaitem", "menu", "paramparser", "parserdata", "pickler", "plugin",
            "proxyinfo", "regexer", "retroconfig", "updater", "urihandler", "vault", "version",
-           "xbmcwrapper"]
+           "xbmcwrapper", "player"]

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: CC-BY-NC-SA-4.0
+
+import xbmc
+
+from resources.lib.logger import Logger
+
+
+# noinspection PyPep8Naming
+class Player(xbmc.Player):
+    def __init__(self, show_subs=False, subs=None):
+        """ Initialises a custom Player object to handle the wait for playback and stop
+
+        :param bool show_subs:  Should we show subs be default
+        :param list[str] subs:  A list of possible subtitles
+
+        Currently only the first subtitle is added.
+
+        """
+
+        xbmc.Player.__init__(self)
+
+        self.show_subs = show_subs
+        self.subs = subs
+        self.__monitor = xbmc.Monitor()
+        self.__playBackEventsTriggered = False
+        self.__playPlayBackEndedEventsTriggered = False
+
+    def waitForPlayBack(self, url=None, time_out=30):
+        """ Blocks the call until playback is started.
+
+        :param str url:         The url that should start playing
+        :param int time_out:    Maximum time to wait.
+
+        This method checks whether the playback started. If an url was specified, it will wait
+        for that url to be the active one playing before returning.
+
+        """
+
+        Logger.debug("Player: Waiting for playback")
+        if self.__is_url_playing(url):
+            self.__playBackEventsTriggered = True
+            Logger.debug("Player: Already Playing")
+            return
+
+        for i in range(0, time_out):
+            if self.__monitor.abortRequested() or self.__is_url_playing(url):
+                if self.__monitor.abortRequested():
+                    Logger.debug("Player: Abort requested (%s)", i)
+                    return
+                else:
+                    Logger.debug("Player: PlayBack started (%s)", i)
+                    return
+
+            self.__monitor.waitForAbort(1)
+            Logger.trace("Player: Waiting for an abort (%s)", i)
+
+        Logger.warning("Player: time-out occurred waiting for playback (%s)", time_out)
+        return
+
+    # The end of playback is 100% working, as a next track does not trigger any revents.
+    # def waitForPlayBackEnded(self):
+    #     Logger.debug("Player: Waiting for playback to end")
+    #
+    #     while not self.__monitor.abortRequested() and not self.__playPlayBackEndedEventsTriggered:
+    #         self.__monitor.waitForAbort(1)
+    #         Logger.trace("Player: Waiting for an abort")
+    #
+    #     if self.__monitor.abortRequested():
+    #         Logger.debug("Player: Abort requested")
+    #     else:
+    #         Logger.debug("Player: PlayBacked ended")
+
+    # region Kodi call-back functions
+    def onAVStarted(self):
+        """ Will be called when Kodi has a video or audiostream """
+
+        Logger.trace("Player: [onAVStarted] called")
+
+        if self.subs:
+            Logger.debug("Player: Setting subtitle: %s", self.subs[0])
+            self.setSubtitles(self.subs[0])
+
+        Logger.debug("Player: Showing subtitles")
+        self.showSubtitles(self.show_subs)
+
+        self.__playBackEventsTriggered = True
+        self.__playPlayBackEndedEventsTriggered = False
+
+    def onPlayBackEnded(self):
+        """ Will be called when [Kodi] stops playing a file """
+        Logger.trace("Player: [onPlayBackEnded] called")
+
+        self.__playBackEventsTriggered = False
+        self.__playPlayBackEndedEventsTriggered = True
+
+    def onPlayBackStopped(self):
+        """ Will be called when [user] stops Kodi playing a file """
+        Logger.trace("Player: [onPlayBackStopped] called")
+
+        self.__playBackEventsTriggered = False
+        self.__playPlayBackEndedEventsTriggered = True
+
+    # Triggered both on stop and start
+    # def onAVChange(self):
+    #     Logger.trace("Player: [onAVChange] called")
+    #
+    #     self.__playBackEventsTriggered = False
+    #     self.__playPlayBackEndedEventsTriggered = True
+    # endregion
+
+    def __is_url_playing(self, url):
+        """ Checks whether the given url is playing
+
+        :param str url: The url to check for playback.
+
+        :return: Indication if the url is actively playing or not.
+        :rtype: bool
+
+        """
+
+        if not self.isPlaying():
+            Logger.trace("Player: Not playing")
+            return False
+
+        if not self.__playBackEventsTriggered:
+            Logger.trace("Player: Playing but the Kodi events did not yet trigger")
+            return False
+
+        # We are playing
+        if url is None or url.startswith("plugin://"):
+            Logger.trace("Player: No valid URL to check playback against: %s", url)
+            return True
+
+        playing_file = self.getPlayingFile()
+        Logger.trace("Player: Checking \n'%s' vs \n'%s'", url, playing_file)
+        return url == playing_file

--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -482,6 +482,8 @@ class Plugin(ParameterParser):
     def play_video_item(self):
         """ Starts the videoitem using a playlist. """
 
+        from resources.lib import player
+
         Logger.debug("Playing videoitem using PlayListMethod")
 
         try:
@@ -526,16 +528,14 @@ class Plugin(ParameterParser):
 
             # Set the mode (if the InputStream Adaptive add-on is used, we also need to set it)
             show_subs = AddonSettings.show_subtitles()
-            # Get the Kodi Player instance (let Kodi decide what player, see
-            # http://forum.kodi.tv/showthread.php?tid=173887&pid=1516662#pid1516662)
-            kodi_player = xbmc.Player()
-            XbmcWrapper.wait_for_player_to_start(kodi_player, logger=Logger.instance(), url=start_url)
 
             # TODO: Apparently if we use the InputStream Adaptive, using the setSubtitles() causes sync issues.
             available_subs = [p.Subtitle for p in media_item.MediaItemParts]
-            if available_subs:
-                kodi_player.setSubtitles(available_subs[0])
-            kodi_player.showSubtitles(show_subs)
+
+            # Get the Kodi Player instance (let Kodi decide what player, see
+            # http://forum.kodi.tv/showthread.php?tid=173887&pid=1516662#pid1516662)
+            kodi_player = player.Player(show_subs=show_subs, subs=available_subs)
+            kodi_player.waitForPlayBack(url=start_url, time_out=10)
 
             xbmcplugin.endOfDirectory(self.handle, True)
         except:

--- a/resources/lib/xbmcwrapper.py
+++ b/resources/lib/xbmcwrapper.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: CC-BY-NC-SA-4.0
 
-import time
 import os
 
 import xbmcgui
@@ -50,6 +49,7 @@ class XbmcDialogProgressWrapper(object):
         """
 
         if not completed:
+            # noinspection PyTypeChecker
             self.progressBarDialog.update(int(perc), self.Line1, self.Line2, status)
         else:
             self.progressBarDialog.close()
@@ -98,6 +98,7 @@ class XbmcDialogProgressBgWrapper:
         """
 
         if not completed:
+            # noinspection PyTypeChecker
             self.progressBarDialog.update(percent=int(perc), heading=self.Heading, message=status)
         else:
             self.progressBarDialog.close()
@@ -362,89 +363,3 @@ class XbmcWrapper:
         if logger:
             logger.trace("Received result: %s", response)
         return response
-
-    @staticmethod
-    def wait_for_player_to_start(player, timeout=10, logger=None, url=None):
-        """ Waits for the status of the player to start.
-
-        Requires: <import addon="xbmc.python" version="2.0"/>
-
-        :param xbmc.Player player:  The Kodi player.
-        :param int timeout:         The time-out to wait for.
-        :param any logger:          A `Logger` instance for logging.
-        :param str url:             The URL that should be playing.
-
-        :return: Indication whether or not the player is playing.
-        :rtype: bool
-
-        """
-        return XbmcWrapper.__wait_for_player(player, 1, timeout, logger, url)
-
-    @staticmethod
-    def wait_for_player_to_end(player, timeout=10, logger=None):
-        """ waits for the status of the player to end
-
-        Requires: <import addon="xbmc.python" version="2.0"/>
-
-        :param xbmc.Player player:  The Kodi player.
-        :param int timeout:         The time-out to wait for.
-        :param any logger:          A `Logger` instance for logging.
-
-        :return: indication if player has stopped.
-        :rtype: bool
-
-        """
-
-        return XbmcWrapper.__wait_for_player(player, 0, timeout, logger, None)
-
-    @staticmethod
-    def __wait_for_player(player, play_state, timeout, logger, url):  # NOSONAR
-        """ waits for the status of the player to be the desired value
-
-        Requires: <import addon="xbmc.python" version="2.0"/>
-
-        :param xbmc.Player player:  The Kodi player.
-        :param in play_state:         The desired play value (1 = start, 0 = stop).
-        :param int timeout:         The time-out to wait for.
-        :param any logger:          A `Logger` instance for logging.
-        :param str|None url:        The URL that should be playing.
-
-        :return: indication if player has started or has stopped.
-        :rtype: bool
-
-        """
-
-        start = time.time()
-
-        if logger:
-            logger.debug("Waiting for Player status '%s'", play_state)
-            if url is None:
-                logger.debug("player.isPlaying is '%s', preferred value is '%s'", player.isPlaying(), play_state)
-            else:
-                logger.debug("player.isPlaying is '%s', preferred value is %s and stream: '%s'",
-                             player.isPlaying(), play_state, url)
-
-        while time.time() - start < timeout:
-            if player.isPlaying() == play_state:
-                if url is None or url.startswith("plugin://"):
-                    # the player stopped in time
-                    if logger:
-                        logger.debug("player.isPlaying obtained the desired value '%s'", play_state)
-                    return True
-
-                playing_file = player.getPlayingFile()
-                if url == playing_file:
-                    if logger:
-                        logger.debug("player.isPlaying obtained the desired value '%s' and correct stream.", play_state)
-                    return True
-
-                if logger:
-                    logger.debug("player.isPlaying obtained the desired value '%s', but incorrect stream: %s",
-                                 play_state, playing_file)
-
-            if logger:
-                logger.debug("player.isPlaying is %s, waiting a cycle", player.isPlaying())
-            time.sleep(1.)
-
-        # a time out occurred
-        return False


### PR DESCRIPTION
We currently have code that polls the default Kodi player to check if playback started. It would be much better to use the built-in events of the Kodi player to do this. Therefore we need a custom Kodi player.

This PR introduces this custom Kodi player that is used to wait for the start of playback.