### PR TITLE
Feature fallback textures

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@ show the video information dialog window.
 * Changed: json should always be text not bytes
 * Updated: a bit more logging if no data was found for decryption
 * Added: Check to see if external add-on is installed
+* Added: Generic functionality to check for local or remote texture
 
 [B]GUI/Settings/Language related[/B]
 * Changed: Move 'expire' date to MediaItem (Fixes #1301)

--- a/changelog.txt
+++ b/changelog.txt
@@ -22,3 +22,4 @@ show the video information dialog window.
 [B]Channel related[/B]
 * Fixed: Stievie became VTM GO. Only live streams are available (Fixes #1310)
 * Removed: premium Norwegian channels (Fixes #1300)
+* Changed: page size to 100 for TV4 Play.se (Fixes #1313)

--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ show the video information dialog window.
 * Changed: Move 'expire' date to MediaItem (Fixes #1301)
 * Translated: Dutch(nl_NL) translations
 * Translated: Swedish (sv_SE) translations
+* Added: Add-on setting that allows the showing of thumbs as fanart if no fanart is present
 
 [B]Channel related[/B]
 * Fixed: Stievie became VTM GO. Only live streams are available (Fixes #1310)

--- a/channels/channel.be/een/chn_een.py
+++ b/channels/channel.be/een/chn_een.py
@@ -117,7 +117,6 @@ class Channel(chn_class.Channel):
             result_set["url"] = "https://mediazone.vrt.be/api/v1/een/assets/%(url)s" % result_set
 
         item = chn_class.Channel.create_video_item(self, result_set)
-        item.fanart = self.parentItem.fanart
         if "year" in result_set and result_set["year"]:
             item.set_date(result_set["year"], result_set["month"], result_set["day"])
         return item
@@ -150,7 +149,6 @@ class Channel(chn_class.Channel):
         # # dummy class
         # url = "http://www.een.be/mediatheek/tag/%s"
         item = MediaItem(result_set["title"], result_set["url"])
-        item.icon = self.icon
         item.type = "folder"
         item.complete = True
 

--- a/channels/channel.be/ketnet/chn_ketnet.py
+++ b/channels/channel.be/ketnet/chn_ketnet.py
@@ -101,7 +101,6 @@ class Channel(chn_class.Channel):
         item.type = 'video'
         item.description = json.get_value("description", fallback=None)
         item.thumb = json.get_value("image", fallback=self.noImage)
-        item.fanart = self.parentItem.fanart
         item.complete = False
         items.append(item)
 

--- a/channels/channel.be/sporza/chn_sporza.py
+++ b/channels/channel.be/sporza/chn_sporza.py
@@ -168,7 +168,6 @@ class Channel(chn_class.Channel):
         name = result_set[1]
 
         item = MediaItem(name.capitalize(), url)
-        item.icon = self.icon
         item.type = "folder"
         item.complete = True
         return item
@@ -231,7 +230,6 @@ class Channel(chn_class.Channel):
         item = MediaItem(name, url)
         item.thumb = thumb
         item.description = desc
-        item.icon = self.icon
         item.type = 'video'
         item.complete = False
 

--- a/channels/channel.be/vier/chn_vier.py
+++ b/channels/channel.be/vier/chn_vier.py
@@ -210,8 +210,6 @@ class Channel(chn_class.Channel):
             # Add clips folder
             clip_title = LanguageHelper.get_localized_string(LanguageHelper.Clips)
             clips = MediaItem("\a.: %s :." % (clip_title,), self.parentItem.url)
-            clips.fanart = self.parentItem.fanart
-            clips.thumb = self.parentItem.thumb
             clips.metaData[self.__meta_playlist] = "clips"
             self.__no_clips = True
             items.append(clips)
@@ -277,8 +275,6 @@ class Channel(chn_class.Channel):
         """
 
         folder = MediaItem(result_set["title"], self.parentItem.url)
-        folder.fanart = self.parentItem.fanart
-        folder.thumb = self.parentItem.thumb
         folder.metaData["current_playlist"] = result_set["id"]
         return folder
 
@@ -338,7 +334,6 @@ class Channel(chn_class.Channel):
         item.type = "video"
         item.description = HtmlHelper.to_text(result_set.get("description").replace(">\r\n", ">"))
         item.thumb = result_set["image"]
-        item.fanart = self.parentItem.fanart
         item.isGeoLocked = result_set.get("isProtected")
 
         date_time = DateHelper.get_date_from_posix(result_set["createdDate"])

--- a/channels/channel.be/vrtnu/chn_vrtnu.py
+++ b/channels/channel.be/vrtnu/chn_vrtnu.py
@@ -288,25 +288,16 @@ class Channel(chn_class.Channel):
             return data, items
 
         cat = MediaItem("\a.: Categori&euml;n :.", "https://www.vrt.be/vrtnu/categorieen.model.json")
-        cat.fanart = self.fanart
-        cat.thumb = self.noImage
-        cat.icon = self.icon
         cat.dontGroup = True
         items.append(cat)
 
         live = MediaItem("\a.: Live Streams :.", "https://services.vrt.be/videoplayer/r/live.json")
-        live.fanart = self.fanart
-        live.thumb = self.noImage
-        live.icon = self.icon
         live.dontGroup = True
         live.isLive = True
         items.append(live)
 
         channel_text = LanguageHelper.get_localized_string(30010)
         channels = MediaItem("\a.: %s :." % (channel_text, ), "#channels")
-        channels.fanart = self.fanart
-        channels.thumb = self.noImage
-        channels.icon = self.icon
         channels.dontGroup = True
         items.append(channels)
 
@@ -365,9 +356,7 @@ class Channel(chn_class.Channel):
         item = MediaItem(title, url)
         item.description = title
         item.thumb = thumb
-        item.icon = self.icon
         item.type = 'folder'
-        item.fanart = self.fanart
         item.HttpHeaders = self.httpHeaders
         item.complete = True
         return item
@@ -462,9 +451,7 @@ class Channel(chn_class.Channel):
         # update artswork
         if item.thumb and item.thumb.startswith("//"):
             item.thumb = "https:%s" % (item.thumb, )
-        else:
-            item.thumb = self.noImage
-        item.fanart = self.fanart
+
         return item
 
     def create_folder_item(self, result_set):
@@ -519,8 +506,6 @@ class Channel(chn_class.Channel):
         description = HtmlHelper.to_text(json_data.get_value("description"))
         item = MediaItem(title, url, type="video")
         item.description = description
-        item.thumb = self.parentItem.thumb
-        item.fanart = self.parentItem.fanart
         return item
 
     def create_video_item(self, result_set):
@@ -560,7 +545,6 @@ class Channel(chn_class.Channel):
             item.thumb = "https:%s" % (item.thumb, )
 
         self.__hasAlreadyVideoItems = True
-        item.fanart = self.parentItem.fanart
         return item
 
     def update_live_video(self, item):

--- a/channels/channel.be/vtm/chn_vtm.py
+++ b/channels/channel.be/vtm/chn_vtm.py
@@ -83,9 +83,6 @@ class Channel(chn_class.Channel):
         # dummy class
         item = MediaItem(result_set[1], "%s/%s" % (self.baseUrl, result_set[0]))
         item.complete = True
-        item.icon = self.icon
-        item.thumb = self.noImage
-        item.complete = True
         if "/het-weer" in item.url:
             item.type = "video"
             item.complete = False

--- a/channels/channel.be/vtmbe/chn_vtmbe.py
+++ b/channels/channel.be/vtmbe/chn_vtmbe.py
@@ -361,8 +361,6 @@ class Channel(chn_class.Channel):
         #
         # search = MediaItem("Zoeken", "searchSite")
         # search.complete = True
-        # search.icon = self.icon
-        # search.thumb = self.noImage
         # search.dontGroup = True
         # items.append(search)
         return data, items
@@ -390,7 +388,6 @@ class Channel(chn_class.Channel):
         live.type = "video"
         live.description = self.parentItem.description
         live.metaData = self.parentItem.metaData
-        live.thumb = self.parentItem.thumb
         items.append(live)
 
         if not self.__adaptiveStreamingAvailable:
@@ -432,8 +429,6 @@ class Channel(chn_class.Channel):
         #
         #     extra = MediaItem(title, url)
         #     extra.complete = True
-        #     extra.icon = self.icon
-        #     extra.thumb = self.noImage
         #     extra.dontGroup = True
         #     extra.set_date(air_date.year, air_date.month, air_date.day, text="")
         #     extra.metaData["airDate"] = air_date
@@ -648,7 +643,6 @@ class Channel(chn_class.Channel):
               "&sort=broadcastDate&sortDirection=desc" \
               "&programIds=%s" % (self.__apiKey, result_set['id'],)
         item = MediaItem(title, url)
-        item.fanart = self.fanart
         item.thumb = self.__find_image(result_set, self.noImage)
         return item
     # endregion
@@ -746,8 +740,6 @@ class Channel(chn_class.Channel):
               "&programIds=%s" % (self.__apiKey, result_set['parent_series_oid'],)
 
         item = MediaItem(title, url)
-        item.fanart = self.fanart
-        item.thumb = self.noImage
         item.description = result_set.get('body', None)
         if item.description:
             # Clean HTML
@@ -795,9 +787,6 @@ class Channel(chn_class.Channel):
 
             more = LanguageHelper.get_localized_string(LanguageHelper.MorePages)
             item = MediaItem(more, url)
-            item.thumb = self.noImage
-            item.icon = self.icon
-            item.fanart = self.parentItem.fanart
             item.complete = True
             items.append(item)
 
@@ -953,8 +942,6 @@ class Channel(chn_class.Channel):
             item = MediaItem("Live Q2", "#livestream")
         item.type = "video"
         item.isLive = True
-        item.fanart = self.fanart
-        item.thumb = self.noImage
         now = datetime.datetime.now()
         item.set_date(now.year, now.month, now.day, now.hour, now.minute, now.second)
         items.append(item)
@@ -962,8 +949,6 @@ class Channel(chn_class.Channel):
         # No more recent items
         # if self.channelCode == "vtm":
         #     recent = MediaItem("\a.: Recent :.", "https://vtm.be/video/volledige-afleveringen/id")
-        #     item.fanart = self.fanart
-        #     item.thumb = self.noImage
         #     item.dontGroup = True
         #     items.append(recent)
 
@@ -1011,8 +996,6 @@ class Channel(chn_class.Channel):
         # http://vtm.be/video/?amp%3Bf[1]=sm_field_program_active%3AAlloo%20bij%20de%20Wegpolitie&f[0]=sm_field_video_origin_cms_longform%3AVolledige%20afleveringen&f[1]=sm_field_program_active%3AAlloo%20bij%20de%20Wegpolitie
 
         item = MediaItem(title, url)
-        item.fanart = self.fanart
-        item.thumb = self.noImage
         return item
 
     def add_more_recent_videos(self, data):

--- a/channels/channel.de/srf/chn_srf.py
+++ b/channels/channel.de/srf/chn_srf.py
@@ -71,8 +71,6 @@ class Channel(chn_class.Channel):
         items = []
 
         live_items = MediaItem("\a.: Live TV :.", "")
-        live_items.thumb = self.noImage
-        live_items.icon = self.icon
         items.append(live_items)
 
         live_base = "http://il.srgssr.ch/integrationlayer/1.0/ue/srf/video/play/%s.json"
@@ -82,7 +80,6 @@ class Channel(chn_class.Channel):
         for live_item in live_channels.keys():
             item = MediaItem(live_item, live_base % (live_channels[live_item][0],))
             item.thumb = self.get_image_location(live_channels[live_item][1])
-            item.icon = self.icon
             item.isGeoLocked = True
             item.type = "video"
             live_items.items.append(item)
@@ -108,7 +105,6 @@ class Channel(chn_class.Channel):
         url = "http://il.srgssr.ch/integrationlayer/1.0/ue/srf/assetSet/listByAssetGroup/%s.json" % (result_set["id"],)
         item = MediaItem(result_set["title"], url)
         item.description = result_set.get("description", "")
-        item.icon = self.icon
         item.httpHeaders = self.httpHeaders
 
         # the 0005 seems to be a quality thing: 0001, 0003, 0004, 0005
@@ -143,7 +139,6 @@ class Channel(chn_class.Channel):
         url = "http://il.srgssr.ch/integrationlayer/1.0/ue/srf/assetSet/listByAssetGroup/%s.json?pageSize=100" % (result_set["id"],)
         item = MediaItem(result_set["title"], url)
         item.description = result_set.get("description", "")
-        item.icon = self.icon
         item.httpHeaders = self.httpHeaders
         item.thumb = self.__get_nested_value(result_set, "Image", "ImageRepresentations", "ImageRepresentation", 0, "url")
         item.complete = True
@@ -198,8 +193,6 @@ class Channel(chn_class.Channel):
         # 2015-01-20 22:17:59"
         date_time = DateHelper.get_date_from_string(date_value, "%Y-%m-%d %H:%M:%S")
         item.set_date(*date_time[0:6])
-
-        item.icon = self.icon
         item.httpHeaders = self.httpHeaders
         item.complete = False
         return item
@@ -252,8 +245,6 @@ class Channel(chn_class.Channel):
         # 2015-01-20T22:17:59"
         date_time = DateHelper.get_date_from_string(date_value, "%Y-%m-%dT%H:%M:%S")
         item.set_date(*date_time[0:6])
-
-        item.icon = self.icon
         item.httpHeaders = self.httpHeaders
         item.complete = False
         return item

--- a/channels/channel.mtg/tvse/chn_tvse.py
+++ b/channels/channel.mtg/tvse/chn_tvse.py
@@ -138,8 +138,6 @@ class Channel(chn_class.Channel):
         title = "\a.: %s :." % (self.searchInfo.get(self.language, self.searchInfo["se"])[1], )
         Logger.trace("Adding search item: %s", title)
         search_item = MediaItem(title, "searchSite")
-        search_item.thumb = self.noImage
-        search_item.fanart = self.fanart
         search_item.dontGroup = True
         items.append(search_item)
 

--- a/channels/channel.mtg/viafree/chn_viafree.py
+++ b/channels/channel.mtg/viafree/chn_viafree.py
@@ -287,8 +287,6 @@ class Channel(chn_class.Channel):
         url = "http://playapi.mtgx.tv/v3/videos/stream/%(id)s" % result_set
         item = MediaItem(result_set["title"], url)
         item.type = "video"
-        item.thumb = self.parentItem.thumb
-        item.icon = self.parentItem.icon
         item.description = result_set.get("summary", None)
 
         aired_at = result_set.get("airedAt", None)
@@ -354,8 +352,6 @@ class Channel(chn_class.Channel):
         if clip_url is not None:
             clip_title = LanguageHelper.get_localized_string(LanguageHelper.Clips)
             clip_item = MediaItem("\a.: %s :." % (clip_title,), clip_url)
-            clip_item.thumb = self.parentItem.thumb
-            clip_item.fanart = self.parentItem.fanart
             items.append(clip_item)
 
         Logger.debug("Pre-Processing finished")
@@ -379,8 +375,6 @@ class Channel(chn_class.Channel):
         title = "\a.: %s :." % (self.searchInfo.get(self.language, self.searchInfo["se"])[1], )
         Logger.trace("Adding search item: %s", title)
         search_item = MediaItem(title, "searchSite")
-        search_item.thumb = self.noImage
-        search_item.fanart = self.fanart
         search_item.dontGroup = True
         items.append(search_item)
 
@@ -440,8 +434,6 @@ class Channel(chn_class.Channel):
 
         item = MediaItem(page, url)
         item.type = "page"
-        item.thumb = self.parentItem.thumb
-        item.fanart = self.parentItem.fanart
 
         Logger.trace("Created '%s' for url %s", item.name, item.url)
         return item
@@ -537,12 +529,9 @@ class Channel(chn_class.Channel):
 
         item.type = "video"
         item.complete = False
-        item.icon = self.icon
         item.isGeoLocked = geo_blocked
         item.isDrmProtected = drm_locked
 
-        item.thumb = self.parentItem.thumb
-        item.fanart = self.parentItem.fanart
         thumb_data = result_set['_links'].get('image', None)
         if thumb_data is not None:
             # Older version
@@ -758,8 +747,6 @@ class Channel(chn_class.Channel):
         else:
             url = "http://playapi.mtgx.tv/v3/videos?format=%(guid)s&order=-airdate&type=program" % result_set
         item = MediaItem(result_set['title'], url)
-        item.icon = self.icon
-        item.thumb = self.noImage
         if "images" in result_set and "landscape" in result_set["images"]:
             image_url = result_set["images"]["landscape"]["href"]
             item.thumb = self.__get_thumb_image(image_url)

--- a/channels/channel.mtv/mtvnl/chn_mtvnl.py
+++ b/channels/channel.mtv/mtvnl/chn_mtvnl.py
@@ -126,7 +126,6 @@ class Channel(chn_class.Channel):
               "?key=networkapp1.0&brand=mtv&platform=android&region=%s&version=2.2" % \
               (result_set["id"], self.__region)
         item = MediaItem(title, url)
-        item.icon = self.icon
         item.description = result_set.get("description", None)
         item.complete = True
 
@@ -178,11 +177,7 @@ class Channel(chn_class.Channel):
 
         item = MediaItem(title, url)
         item.type = "video"
-        item.icon = self.icon
         item.description = result_set.get("description", None)
-
-        item.thumb = self.parentItem.thumb
-        item.fanart = self.parentItem.fanart
         item.isGeoLocked = True
         images = result_set.get("images", [])
         if images:
@@ -241,7 +236,6 @@ class Channel(chn_class.Channel):
         url = "%sepisodes.json?per=2147483647&franchise_id=%s" % (self.mainListUri[0:43], serie_id)
 
         item = MediaItem(title, url)
-        item.icon = self.icon
         item.complete = True
 
         # thumbs
@@ -315,7 +309,6 @@ class Channel(chn_class.Channel):
         item = MediaItem(title, url)
         item.thumb = thumb
         item.description = description
-        item.icon = self.icon
         item.type = 'video'
         item.set_date(date[0], date[1], date[2])
         item.complete = False

--- a/channels/channel.mtv/southpark/chn_southpark.py
+++ b/channels/channel.mtv/southpark/chn_southpark.py
@@ -74,7 +74,6 @@ class Channel(chn_class.Channel):
         url = "%s/feeds/full-episode/carousel/%s/%s" % (self.baseUrl, result_set[2], self.promotionId)
 
         item = MediaItem("Season %02d" % int(result_set[2]), url)
-        item.icon = self.icon
         item.complete = True
         return item
 
@@ -113,7 +112,6 @@ class Channel(chn_class.Channel):
         #
         # item = MediaItem(title, url)
         # item.thumb = helper.GetNamedValue("thumbnail_190")
-        # item.icon = self.icon
         # item.description = helper.GetNamedValue("description")
         # item.type = 'video'
         # item.complete = False

--- a/channels/channel.nick/nickjr/chn_nickjr.py
+++ b/channels/channel.nick/nickjr/chn_nickjr.py
@@ -134,9 +134,7 @@ class Channel(chn_class.Channel):
         # http://www.nickjr.nl/data/propertyStreamPage.json?&urlKey=dora&apiKey=nl_global_Nickjr_web&page=1
         url = "%s/data/propertyStreamPage.json?&urlKey=%s&apiKey=%s&page=1" % (self.baseUrl, result_set["seriesKey"], self.__apiKey)
         item = MediaItem(title, url)
-        item.icon = self.icon
         item.complete = True
-        item.fanart = self.fanart
         item.HttpHeaders = self.httpHeaders
         return item
 
@@ -163,9 +161,6 @@ class Channel(chn_class.Channel):
         more = LanguageHelper.get_localized_string(LanguageHelper.MorePages)
         url = "%s=%s" % (self.parentItem.url.rsplit("=", 1)[0], next_page)
         item = MediaItem(more, url)
-        item.thumb = self.parentItem.thumb
-        item.icon = self.icon
-        item.fanart = self.parentItem.fanart
         item.complete = True
         return item
 
@@ -236,8 +231,6 @@ class Channel(chn_class.Channel):
         item = MediaItem(title, url)
         item.description = result_set.get("description", None)
         item.type = "video"
-        item.icon = self.icon
-        item.fanart = self.fanart
         item.HttpHeaders = self.httpHeaders
         item.complete = False
 

--- a/channels/channel.no/nrkno/chn_nrkno.py
+++ b/channels/channel.no/nrkno/chn_nrkno.py
@@ -169,8 +169,6 @@ class Channel(chn_class.Channel):
         }
         for name, url in links.items():
             item = MediaItem(name, url)
-            item.icon = self.icon
-            item.thumb = self.noImage
             item.complete = True
             item.HttpHeaders = self.httpHeaders
             items.append(item)
@@ -226,10 +224,7 @@ class Channel(chn_class.Channel):
 
         title = LanguageHelper.get_localized_string(LanguageHelper.StartWith) % (title, )
         item = MediaItem(title, url)
-        item.icon = self.icon
         item.type = 'folder'
-        item.fanart = self.fanart
-        item.thumb = self.noImage
         return item
 
     def create_category_item(self, result_set):
@@ -251,9 +246,7 @@ class Channel(chn_class.Channel):
         url = "https://psapi.nrk.no/medium/tv/categories/{}/indexelements?apiKey={}"\
             .format(category_id, self.__api_key)
         item = MediaItem(title, url)
-        item.icon = self.icon
         item.type = 'folder'
-        item.fanart = self.fanart
         item.thumb = self.__category_thumbs.get(category_id.lower(), self.noImage)
         return item
 
@@ -386,7 +379,6 @@ class Channel(chn_class.Channel):
             item = MediaItem(title, url)
             item.type = 'folder'
 
-        item.icon = self.icon
         item.isGeoLocked = result_set.get("isGeoBlocked", result_set.get("usageRights", {}).get("isGeoBlocked", False))
 
         description = result_set.get("description")
@@ -431,8 +423,6 @@ class Channel(chn_class.Channel):
         url = "{}/seasons/{}/episodes?apiKey={}".format(parent_url, season_id, self.__api_key)
         item = MediaItem(title, url)
         item.type = 'folder'
-        item.thumb = self.parentItem.thumb
-        item.fanart = self.parentItem.fanart
         return item
 
     def create_series_video_item(self, result_set):
@@ -505,8 +495,6 @@ class Channel(chn_class.Channel):
 
         item = MediaItem(title, url)
         item.type = 'folder'
-        item.thumb = self.parentItem.thumb
-        item.fanart = self.parentItem.fanart
         return item
 
     def create_instalment_video_item(self, result_set):
@@ -540,7 +528,6 @@ class Channel(chn_class.Channel):
         item = MediaItem(title, url)
         item.type = 'video'
         item.thumb = self.__get_image(result_set["image"], "width", "url")
-        item.fanart = self.parentItem.fanart
 
         # noinspection PyTypeChecker
         item.isGeoLocked = result_set.get("usageRights", {}).get("geoBlock", {}).get("isGeoBlocked", False)

--- a/channels/channel.nos/nos2010/chn_nos2010.py
+++ b/channels/channel.nos/nos2010/chn_nos2010.py
@@ -320,8 +320,6 @@ class Channel(chn_class.Channel):
             title = LanguageHelper.get_localized_string(LanguageHelper.MorePages)
             title = "\a.: %s :." % (title,)
             more = MediaItem(title, next_page)
-            more.thumb = self.parentItem.thumb
-            more.fanart = self.parentItem.fanart
             more.HttpHeaders = http_headers
             more.HttpHeaders.update(self.parentItem.HttpHeaders)
             items.append(more)
@@ -341,8 +339,6 @@ class Channel(chn_class.Channel):
         items = []
         search = MediaItem(LanguageHelper.get_localized_string(LanguageHelper.Search), "searchSite")
         search.complete = True
-        search.icon = self.icon
-        search.thumb = self.noImage
         search.dontGroup = True
         search.HttpHeaders = {"X-Requested-With": "XMLHttpRequest"}
         items.append(search)
@@ -353,8 +349,6 @@ class Channel(chn_class.Channel):
         favs.complete = True
         favs.description = "Favorieten van de NPO.nl website. Het toevoegen van favorieten " \
                            "wordt nog niet ondersteund."
-        favs.icon = self.icon
-        favs.thumb = self.noImage
         favs.dontGroup = True
         favs.HttpHeaders = {"X-Requested-With": "XMLHttpRequest"}
         items.append(favs)
@@ -362,16 +356,12 @@ class Channel(chn_class.Channel):
         extra = MediaItem(LanguageHelper.get_localized_string(LanguageHelper.LiveRadio),
                           "http://radio-app.omroep.nl/player/script/player.js")
         extra.complete = True
-        extra.icon = self.icon
-        extra.thumb = self.noImage
         extra.dontGroup = True
         items.append(extra)
 
         extra = MediaItem(LanguageHelper.get_localized_string(LanguageHelper.LiveTv),
                           "%s/live" % (self.baseUrlLive,))
         extra.complete = True
-        extra.icon = self.icon
-        extra.thumb = self.noImage
         extra.dontGroup = True
         items.append(extra)
 
@@ -383,8 +373,6 @@ class Channel(chn_class.Channel):
             "https://start-api.npo.nl/page/catalogue?pageSize={}".format(self.__pageSize))
 
         extra.complete = True
-        extra.icon = self.icon
-        extra.thumb = self.noImage
         extra.dontGroup = True
         extra.description = "Volledige programma lijst van NPO Start."
         extra.HttpHeaders = self.__jsonApiKeyHeader
@@ -394,8 +382,6 @@ class Channel(chn_class.Channel):
         extra = MediaItem(LanguageHelper.get_localized_string(LanguageHelper.Genres),
                           "https://www.npostart.nl/programmas")
         extra.complete = True
-        extra.icon = self.icon
-        extra.thumb = self.noImage
         extra.dontGroup = True
         items.append(extra)
 
@@ -403,16 +389,12 @@ class Channel(chn_class.Channel):
             "{} (A-Z)".format(LanguageHelper.get_localized_string(LanguageHelper.TvShows)),
             "#alphalisting")
         extra.complete = True
-        extra.icon = self.icon
-        extra.thumb = self.noImage
         extra.description = "Alfabetische lijst van de NPO.nl site."
         extra.dontGroup = True
         items.append(extra)
 
         recent = MediaItem(LanguageHelper.get_localized_string(LanguageHelper.Recent), "#recent")
         recent.complete = True
-        recent.icon = self.icon
-        recent.thumb = self.noImage
         recent.dontGroup = True
         items.append(recent)
 
@@ -454,8 +436,6 @@ class Channel(chn_class.Channel):
                       (air_date.year, air_date.month, air_date.day)
             extra = MediaItem(title, url)
             extra.complete = True
-            extra.icon = self.icon
-            extra.thumb = self.noImage
             extra.dontGroup = True
             if self.__useJson:
                 extra.HttpHeaders = self.__jsonApiKeyHeader
@@ -559,8 +539,6 @@ class Channel(chn_class.Channel):
                 char = "0-9"
             sub_item = MediaItem(title_format % (char,), url_format % (char,))
             sub_item.complete = True
-            sub_item.icon = self.icon
-            sub_item.thumb = self.noImage
             sub_item.dontGroup = True
             sub_item.HttpHeaders = {"X-Requested-With": "XMLHttpRequest"}
             items.append(sub_item)
@@ -681,7 +659,6 @@ class Channel(chn_class.Channel):
 
         item = MediaItem(name, url)
         item.type = 'folder'
-        item.icon = self.icon
         item.complete = True
         item.description = description
         if self.__useJson:
@@ -754,10 +731,8 @@ class Channel(chn_class.Channel):
         channel = result_set["channel"].replace("NED", "NPO ")
         title = "{0[hours]}:{0[minutes]} - {1} - {0[title]}".format(result_set, channel)
         item = MediaItem(title, result_set["url"])
-        item.icon = self.icon
         item.description = result_set["channel"]
         item.type = 'video'
-        item.fanart = self.fanart
         item.HttpHeaders = self.httpHeaders
         item.complete = False
         return item
@@ -837,7 +812,6 @@ class Channel(chn_class.Channel):
         if next_url:
             next_title = LanguageHelper.get_localized_string(LanguageHelper.MorePages)
             item = MediaItem(next_title, next_url)
-            item.fanart = self.parentItem.fanart
             item.complete = True
             item.HttpHeaders = self.__jsonApiKeyHeader
             items.append(item)
@@ -918,7 +892,6 @@ class Channel(chn_class.Channel):
         item.set_info_label("duration", result_set['duration'])
 
         images = result_set["images"]
-        item.fanart = self.parentItem.fanart
         for image_type, image_data in images.items():
             if image_type == "original" and "original" in image_data["formats"]:
                 continue
@@ -1052,7 +1025,6 @@ class Channel(chn_class.Channel):
         title = " - ".join(set(names))
 
         item = MediaItem(title, video_id)
-        item.icon = self.icon
         item.type = 'video'
         item.complete = False
         item.description = description
@@ -1095,10 +1067,7 @@ class Channel(chn_class.Channel):
 
         url = "https://www.npostart.nl/media/collections/%s?page=1&tileMapping=normal&tileType=asset&pageType=collection" % (result_set[0],)
         item = MediaItem(result_set[1], url)
-        item.thumb = self.parentItem.thumb
-        item.icon = self.parentItem.icon
         item.type = 'folder'
-        item.fanart = self.parentItem.fanart
         item.HttpHeaders["X-Requested-With"] = "XMLHttpRequest"
         item.complete = True
         return item
@@ -1151,7 +1120,6 @@ class Channel(chn_class.Channel):
         else:
             item.thumb = "%s%s" % (self.baseUrlLive, result_set[1].replace("regular_", "").replace("larger_", ""))
 
-        item.icon = self.icon
         item.complete = False
         item.isLive = True
         return item
@@ -1182,8 +1150,6 @@ class Channel(chn_class.Channel):
             return None
 
         item = MediaItem(name, "", type="audio")
-        item.thumb = self.parentItem.thumb
-        item.icon = self.icon
         item.isLive = True
         item.complete = False
 

--- a/channels/channel.nos/nosnl/chn_nosnl.py
+++ b/channels/channel.nos/nosnl/chn_nosnl.py
@@ -105,8 +105,6 @@ class Channel(chn_class.Channel):
 
         for cat in cats:
             item = MediaItem(cat, cats[cat])
-            item.thumb = self.noImage
-            item.icon = self.icon
             item.complete = True
             items.append(item)
 
@@ -132,8 +130,6 @@ class Channel(chn_class.Channel):
             title = LanguageHelper.get_localized_string(LanguageHelper.MorePages)
             url = result_set['next']
             item = MediaItem(title, url)
-            item.fanart = self.parentItem.fanart
-            item.thumb = self.parentItem.thumb
             items.append(item)
 
         return items
@@ -165,7 +161,6 @@ class Channel(chn_class.Channel):
 
         url = "https://api.nos.nl/mobile/video/%s/phone.json" % (video_id, )
         item = MediaItem(result_set['title'], url, type="video")
-        item.icon = self.icon
         if 'image' in result_set:
             images = result_set['image']["formats"]
             matched_image = images[-1]

--- a/channels/channel.nos/schooltv/chn_schooltv.py
+++ b/channels/channel.nos/schooltv/chn_schooltv.py
@@ -92,8 +92,6 @@ class Channel(chn_class.Channel):
         url = "http://m.schooltv.nl/api/v1/programmas/%s/afleveringen.json?size=%s&sort=Nieuwste" % (result_set['mid'], self.__PageSize)
         item = MediaItem(result_set['title'], url)
         item.thumb = result_set.get('image', self.noImage)
-        item.icon = self.icon
-
         item.description = result_set.get('description', None)
         age_groups = result_set.get('ageGroups', ['Onbekend'])
         item.description = "%s\n\nLeeftijden: %s" % (item.description, ", ".join(age_groups))
@@ -121,27 +119,18 @@ class Channel(chn_class.Channel):
 
         cat = MediaItem("\b.: Categorie&euml;n :.",
                         "http://m.schooltv.nl/api/v1/categorieen.json?size=100")
-        cat.thumb = self.noImage
-        cat.icon = self.icon
-        cat.fanart = self.fanart
         cat.complete = True
         cat.dontGroup = True
         items.append(cat)
 
         tips = MediaItem("\b.: Tips :.",
                          "http://m.schooltv.nl/api/v1/programmas/tips.json?size=100")
-        tips.thumb = self.noImage
-        tips.icon = self.icon
-        tips.fanart = self.fanart
         tips.complete = True
         tips.dontGroup = True
         items.append(tips)
 
         data = JsonHelper(data)
         ages = MediaItem("\b.: Leeftijden :.", "")
-        ages.thumb = self.noImage
-        ages.icon = self.icon
-        ages.fanart = self.fanart
         ages.complete = True
         ages.dontGroup = True
         for age in ("0-4", "5-6", "7-8", "9-12", "13-15", "16-18"):
@@ -149,9 +138,6 @@ class Channel(chn_class.Channel):
                 "%s Jaar" % (age,),
                 "http://m.schooltv.nl/api/v1/leeftijdscategorieen/%s/afleveringen.json?"
                 "size=%s&sort=Nieuwste" % (age, self.__PageSize))
-            age_item.thumb = self.noImage
-            age_item.icon = self.icon
-            age_item.fanart = self.fanart
             age_item.complete = True
             age_item.dontGroup = True
             ages.items.append(age_item)
@@ -186,7 +172,6 @@ class Channel(chn_class.Channel):
         item = MediaItem(result_set['title'], url)
         item.thumb = result_set.get('image', self.noImage)
         item.description = "Totaal %(count)s videos" % result_set
-        item.icon = self.icon
         return item
 
     def add_page_items(self, data):
@@ -220,9 +205,6 @@ class Channel(chn_class.Channel):
             Logger.debug("Adding next-page item from %s to %s", from_value + size_value, from_value + size_value + size_value)
 
             next_page = MediaItem(more_pages, url)
-            next_page.icon = self.parentItem.icon
-            next_page.fanart = self.parentItem.fanart
-            next_page.thumb = self.parentItem.thumb
             next_page.dontGroup = True
             items.append(next_page)
 
@@ -265,9 +247,7 @@ class Channel(chn_class.Channel):
         item.description = "%s\n\nLeeftijden: %s" % (item.description, ", ".join(age_groups))
 
         item.thumb = result_set.get("image", "")
-        item.icon = self.icon
         item.type = 'video'
-        item.fanart = self.fanart
         item.complete = False
         item.set_info_label("duration", result_set['duration'])
 

--- a/channels/channel.regionalnl/at5/chn_at5.py
+++ b/channels/channel.regionalnl/at5/chn_at5.py
@@ -151,8 +151,6 @@ class Channel(chn_class.Channel):
 
         url = "https://at5news.vinsontv.com/api/news?source=web&externalid={}".format(result_set["externalId"])
         item = MediaItem(result_set["title"], url)
-        item.icon = self.icon
-        item.thumb = self.noImage
         item.complete = True
         item.description = result_set.get("text")
 
@@ -195,7 +193,6 @@ class Channel(chn_class.Channel):
 
         item = MediaItem(result_set["title"], url)
         item.type = "video"
-        item.icon = self.icon
         item.thumb = thumb or self.noImage
         item.complete = True
         item.description = HtmlHelper.to_text(result_set.get("text"))

--- a/channels/channel.regionalnl/flevo/chn_flevo.py
+++ b/channels/channel.regionalnl/flevo/chn_flevo.py
@@ -86,8 +86,6 @@ class Channel(chn_class.Channel):
                 "\a.: Live TV :.",
                 "https://d5ms27yy6exnf.cloudfront.net/live/omroepflevoland/tv/index.m3u8"
             )
-            live_item.icon = self.icon
-            live_item.thumb = self.noImage
             live_item.type = 'video'
             live_item.dontGroup = True
             now = datetime.datetime.now()
@@ -98,8 +96,6 @@ class Channel(chn_class.Channel):
                 "\a.: Live Radio :.",
                 "https://d5ms27yy6exnf.cloudfront.net/live/omroepflevoland/radio/index.m3u8"
             )
-            live_item.icon = self.icon
-            live_item.thumb = self.noImage
             live_item.type = 'video'
             live_item.dontGroup = True
             now = datetime.datetime.now()
@@ -113,9 +109,6 @@ class Channel(chn_class.Channel):
         url = "{}={}".format(url, int(page) + 1)
 
         item = MediaItem(more, url)
-        item.thumb = self.noImage
-        item.icon = self.icon
-        item.fanart = self.fanart
         item.complete = True
         items.append(item)
 

--- a/channels/channel.regionalnl/gelderland/chn_gelderland.py
+++ b/channels/channel.regionalnl/gelderland/chn_gelderland.py
@@ -64,7 +64,6 @@ class Channel(chn_class.Channel):
         """
 
         item = MediaItem(result_set[2], "%s%s" % (self.baseUrl, result_set[0]))
-        item.icon = self.icon
         item.thumb = "%s%s" % (self.baseUrl, result_set[1])
         item.complete = True
         return item
@@ -104,7 +103,6 @@ class Channel(chn_class.Channel):
         
         item = MediaItem(name, url)
         item.thumb = thumb_url
-        item.icon = self.icon
         item.type = 'video'
         item.append_single_stream(video_url)
         

--- a/channels/channel.regionalnl/l1/chn_l1.py
+++ b/channels/channel.regionalnl/l1/chn_l1.py
@@ -177,10 +177,8 @@ class Channel(chn_class.Channel):
         title = result_set[6]
 
         item = MediaItem(title, url)
-        item.thumb = self.noImage
         if thumb_url:
             item.thumb = thumb_url
-        item.icon = self.icon
         item.type = 'video'
 
         if result_set[3]:

--- a/channels/channel.regionalnl/lokaal/chn_lokaal.py
+++ b/channels/channel.regionalnl/lokaal/chn_lokaal.py
@@ -164,8 +164,6 @@ class Channel(chn_class.Channel):
         if self.liveUrl:
             Logger.debug("Adding live item")
             live_item = MediaItem("\aLive TV", self.liveUrl)
-            live_item.icon = self.icon
-            live_item.thumb = self.noImage
             live_item.dontGroup = True
             items.append(live_item)
 
@@ -198,8 +196,6 @@ class Channel(chn_class.Channel):
             title = "{} - {}".format(self.channelName, LanguageHelper.get_localized_string(LanguageHelper.LiveStreamTitleId))
             live_item = MediaItem(title, self.liveUrl)
             live_item.type = 'video'
-            live_item.icon = self.icon
-            live_item.thumb = self.noImage
             live_item.isLive = True
             if self.channelCode == "rtvdrenthe":
                 # RTV Drenthe actually has a buggy M3u8 without master index.
@@ -231,8 +227,6 @@ class Channel(chn_class.Channel):
             live_item = MediaItem(title, self.liveUrl)
             live_item.type = 'video'
             live_item.complete = True
-            live_item.icon = self.icon
-            live_item.thumb = self.noImage
             live_item.isLive = True
             part = live_item.create_new_empty_media_part()
             for stream in streams:
@@ -327,8 +321,6 @@ class Channel(chn_class.Channel):
             link = parse.urljoin(self.baseUrl, link)
 
         item = MediaItem(title, link)
-        item.icon = self.icon
-        item.thumb = self.noImage
         item.complete = True
         return item
 
@@ -364,7 +356,6 @@ class Channel(chn_class.Channel):
             url = parse.urljoin(self.baseUrl, url)
 
         item = MediaItem(title, url)
-        item.thumb = self.noImage
 
         if media_link:
             item.append_single_stream(media_link, self.channelBitrate)
@@ -382,13 +373,10 @@ class Channel(chn_class.Channel):
         if thumb_url and not thumb_url.startswith("http"):
             thumb_url = parse.urljoin(self.baseUrl, thumb_url)
 
-        item.thumb = self.noImage
         if thumb_url:
             item.thumb = thumb_url
 
-        item.icon = self.icon
         item.type = 'video'
-
         item.description = HtmlHelper.to_text(result_set.get("text"))
 
         posix = result_set.get("timestamp", None)

--- a/channels/channel.rtlnl/rtl/chn_rtl.py
+++ b/channels/channel.rtlnl/rtl/chn_rtl.py
@@ -104,15 +104,11 @@ class Channel(chn_class.Channel):
 
         # let's add the RTL-Z live stream
         rtlz_live = MediaItem("RTL Z Live Stream", "")
-        rtlz_live.icon = self.icon
-        rtlz_live.thumb = self.noImage
         rtlz_live.complete = True
         rtlz_live.isLive = True
         rtlz_live.dontGroup = True
 
         stream_item = MediaItem("RTL Z: Live Stream", "http://www.rtl.nl/(config=RTLXLV2,channel=rtlxl,progid=rtlz,zone=inlineplayer.rtl.nl/rtlz,ord=0)/system/video/wvx/components/financien/rtlz/miMedia/livestream/rtlz_livestream.xml/1500.wvx")
-        stream_item.icon = self.icon
-        stream_item.thumb = self.noImage
         stream_item.complete = True
         stream_item.type = "video"
         stream_item.dontGroup = True
@@ -168,8 +164,6 @@ class Channel(chn_class.Channel):
                   "{0:04d}{1:02d}{2:02d}/".format(air_date.year, air_date.month, air_date.day)
             extra = MediaItem(title, url)
             extra.complete = True
-            extra.icon = self.icon
-            extra.thumb = self.noImage
             extra.dontGroup = True
             extra.set_date(air_date.year, air_date.month, air_date.day, text="")
 
@@ -202,8 +196,6 @@ class Channel(chn_class.Channel):
         key = result_set.get("key", result_set["abstract_key"])
         url = "http://www.rtl.nl/system/s4m/vfd/version=1/d=pc/output=json/fun=getseasons/ak=%s" % (key,)
         item = MediaItem(title, url)
-        item.icon = self.icon
-        item.fanart = self.fanart
         item.complete = True
 
         desc = result_set.get("synopsis", "")
@@ -491,8 +483,6 @@ class Channel(chn_class.Channel):
         abstract_key = result_set["AbstractKey"]
         url = "http://www.rtl.nl/system/s4m/vfd/version=1/d=pc/output=json/fun=getseasons/ak={}".format(abstract_key)
         item = MediaItem(title, url)
-        item.thumb = self.parentItem.thumb
-        item.fanart = self.parentItem.fanart
 
         time_stamp = result_set["LastBroadcastDate"]  # =1546268400000
         date_time = DateHelper.get_date_from_posix(int(time_stamp)/1000)

--- a/channels/channel.sbsnl/kijknl/chn_kijknl.py
+++ b/channels/channel.sbsnl/kijknl/chn_kijknl.py
@@ -176,8 +176,6 @@ class Channel(chn_class.Channel):
 
         search = MediaItem("\b.: Zoeken :.", "searchSite")
         search.complete = True
-        search.icon = self.icon
-        search.thumb = self.noImage
         search.dontGroup = True
         search.HttpHeaders = {"X-Requested-With": "XMLHttpRequest"}
         items.append(search)
@@ -186,8 +184,6 @@ class Channel(chn_class.Channel):
             live = LanguageHelper.get_localized_string(LanguageHelper.LiveStreamTitleId)
             live_radio = MediaItem("Radio Veronica {}".format(live), "")
             live_radio.type = "video"
-            live_radio.icon = self.icon
-            live_radio.thumb = self.noImage
             live_radio.dontGroup = True
 
             part = live_radio.create_new_empty_media_part()
@@ -355,8 +351,6 @@ class Channel(chn_class.Channel):
 
         url = "{}?limit=100&offset=1".format(result_set["episodesLink"])
         item = MediaItem(result_set["title"], url)
-        item.fanart = self.parentItem.fanart
-        item.thumb = self.parentItem.thumb
         return item
 
     def create_json_episode_item(self, result_set):

--- a/channels/channel.se/changelog.txt
+++ b/channels/channel.se/changelog.txt
@@ -1,4 +1,5 @@
 ﻿﻿[B]Changelog[/B]
+* Changed: page size to 100 for TV4 Play.se (Fixes #1313)
 * Changed: Move 'expire' date to MediaItem (Fixes #1301)
 * Removed: premium Norwegian channels (Fixes #1300)
 

--- a/channels/channel.se/oppetarkiv/chn_oppetarkiv.py
+++ b/channels/channel.se/oppetarkiv/chn_oppetarkiv.py
@@ -88,18 +88,14 @@ class Channel(chn_class.Channel):
 
         search_item = MediaItem("\a.: S&ouml;k :.", "searchSite")
         search_item.complete = True
-        search_item.thumb = self.noImage
         search_item.dontGroup = True
-        search_item.fanart = self.fanart
         # search_item.set_date(2099, 1, 1, text="")
         # -> No items have dates, so adding this will force a date sort in Retrospect
         items.append(search_item)
 
         genres_item = MediaItem("\a.: Genrer :.", "")
         genres_item.complete = True
-        genres_item.thumb = self.noImage
         genres_item.dontGroup = True
-        genres_item.fanart = self.fanart
         items.append(genres_item)
 
         # find the actual genres
@@ -112,8 +108,6 @@ class Channel(chn_class.Channel):
                 continue
             genre_item = MediaItem(genre["title"], self.mainListUri)
             genre_item.complete = True
-            genre_item.thumb = self.noImage
-            genre_item.fanart = self.fanart
             genre_item.metaData = {"genre": genre["genre"]}
             genres_item.items.append(genre_item)
 
@@ -190,8 +184,6 @@ class Channel(chn_class.Channel):
         url = "%s?sida=1&amp;sort=tid_stigande&embed=true" % (url, )
 
         item = MediaItem(result_set[2], url)
-        item.icon = self.icon
-        item.thumb = self.noImage
         item.complete = True
         item.isGeoLocked = True
         return item
@@ -234,7 +226,6 @@ class Channel(chn_class.Channel):
         url = "http://www.oppetarkiv.se/video/%s?output=json" % (video_id,)
         item = MediaItem(name, url)
         item.type = 'video'
-        item.icon = self.icon
         item.thumb = thumb_url
 
         date = result_set[5]

--- a/channels/channel.se/sbs/chn_sbs.py
+++ b/channels/channel.se/sbs/chn_sbs.py
@@ -276,7 +276,6 @@ class Channel(chn_class.Channel):
             recent_text = LanguageHelper.get_localized_string(LanguageHelper.Recent)
             recent = MediaItem("\b.: {} :.".format(recent_text), self.recentUrl)
             recent.dontGroup = True
-            recent.fanart = self.fanart
             items.append(recent)
 
         # live items
@@ -286,13 +285,11 @@ class Channel(chn_class.Channel):
             live.dontGroup = True
             live.isGeoLocked = True
             live.isLive = True
-            live.fanart = self.fanart
             items.append(live)
 
         search = MediaItem("\a.: S&ouml;k :.", "searchSite")
         search.type = "folder"
         search.dontGroup = True
-        search.fanart = self.fanart
         items.append(search)
 
         return data, items
@@ -380,8 +377,6 @@ class Channel(chn_class.Channel):
         title = LanguageHelper.get_localized_string(LanguageHelper.MorePages)
         url = url_format.format(page + 1)
         item = MediaItem(title, url)
-        item.fanart = self.parentItem.fanart
-        item.thumb = self.parentItem.thumb
         return item
 
     def search_site(self, url=None):
@@ -504,15 +499,11 @@ class Channel(chn_class.Channel):
             item.name = "s{0:02d}e{1:02d} - {2}".format(season, episode, item.name)
             item.set_season_info(season, episode)
 
-        item.fanart = self.parentItem.fanart
         if include_show_title:
             show_id = result_set["relationships"].get("show", {}).get("data", {}).get("id")
             if show_id:
                 show = self.showLookup[show_id]
                 item.name = "{0} - {1}".format(show, item.name)
-
-            if item.thumb != self.noImage:
-                item.fanart = item.thumb
 
         if "videoDuration" in video_info:
             item.set_info_label(MediaItem.LabelDuration, video_info["videoDuration"] / 1000)

--- a/channels/channel.se/svt/chn_svt.py
+++ b/channels/channel.se/svt/chn_svt.py
@@ -175,7 +175,6 @@ class Channel(chn_class.Channel):
         for title, (url, include_subheading) in extra_items.items():
             new_item = MediaItem("\a.: %s :." % (title, ), url)
             new_item.complete = True
-            new_item.thumb = self.noImage
             new_item.dontGroup = True
             new_item.metaData[self.__filter_subheading] = include_subheading
             items.append(new_item)
@@ -188,7 +187,6 @@ class Channel(chn_class.Channel):
         genre_url = self.__get_api_url("AllGenres", "6bef51146d05b427fba78f326453127f7601188e46038c9a5c7b9c2649d4719c", {})
         genre_item = MediaItem(genre_tags, genre_url)
         genre_item.complete = True
-        genre_item.thumb = self.noImage
         genre_item.dontGroup = True
         items.append(genre_item)
 
@@ -259,7 +257,6 @@ class Channel(chn_class.Channel):
             LanguageHelper.get_localized_string(LanguageHelper.Categories))
         new_item = MediaItem(category_title, "https://www.svtplay.se/genre")
         new_item.complete = True
-        new_item.thumb = self.noImage
         new_item.dontGroup = True
         for title, (category_id, thumb) in category_items.items():
             # https://api.svt.se/contento/graphql?ua=svtplaywebb-play-render-prod-client&operationName=GenreProgramsAO&variables={"genre": ["action-och-aventyr"]}&extensions={"persistedQuery": {"version": 1, "sha256Hash": "189b3613ec93e869feace9a379cca47d8b68b97b3f53c04163769dcffa509318"}}
@@ -333,7 +330,6 @@ class Channel(chn_class.Channel):
         url = result_set["urls"]["svtplay"]
         item = MediaItem(result_set['name'], "#program_item")
         item.metaData["slug"] = url
-        item.icon = self.icon
         item.isGeoLocked = result_set.get('restrictions', {}).get('onlyAvailableInSweden', False)
         item.description = result_set.get('longDescription')
 
@@ -363,7 +359,6 @@ class Channel(chn_class.Channel):
         url = result_set["urls"]["svtplay"]
         item = MediaItem(result_set['name'], "#program_item")
         item.metaData["slug"] = url
-        item.icon = self.icon
         item.isGeoLocked = result_set.get('restrictions', {}).get('onlyAvailableInSweden', False)
         item.description = result_set.get('description')
         image_info = result_set.get("image")
@@ -495,8 +490,6 @@ class Channel(chn_class.Channel):
 
         if "image" in result_set:
             item.thumb = self.__get_thumb(result_set["image"], width=720)
-            if not bool(item.fanart):
-                item.fanart = self.__get_thumb(result_set["image"])
 
         valid_from = result_set.get("validFrom", None)
         if bool(valid_from) and valid_from.endswith("Z"):
@@ -660,8 +653,6 @@ class Channel(chn_class.Channel):
         """
 
         item = MediaItem(result_set["name"], "#genre_item")
-        item.fanart = self.fanart
-        item.thumb = self.noImage
         item.metaData[self.__genre_id] = result_set["id"]
         return item
 

--- a/channels/channel.se/tv4se/chn_tv4se.py
+++ b/channels/channel.se/tv4se/chn_tv4se.py
@@ -85,7 +85,7 @@ class Channel(chn_class.Channel):
 
         #===============================================================================================================
         # non standard items
-        self.maxPageSize = 25  # The Android app uses a page size of 20
+        self.maxPageSize = 100  # The Android app uses a page size of 20
 
         #===============================================================================================================
         # Test cases:

--- a/channels/channel.se/tv4se/chn_tv4se.py
+++ b/channels/channel.se/tv4se/chn_tv4se.py
@@ -240,7 +240,6 @@ class Channel(chn_class.Channel):
             return None
 
         item = MediaItem(title, url)
-        item.icon = self.icon
         item.thumb = result_set.get("program_image", self.noImage)
         item.fanart = result_set.get("program_image", self.fanart)
         item.isPaid = result_set.get("is_premium", False)
@@ -334,7 +333,6 @@ class Channel(chn_class.Channel):
             item = MediaItem(title, url)
             item.dontGroup = True
             item.complete = True
-            item.thumb = self.noImage
             item.HttpHeaders = self.httpHeaders
             item.isLive = is_live
 
@@ -413,9 +411,6 @@ class Channel(chn_class.Channel):
                   "type=clip&page=1&node_nids=%s&start=0" % (self.maxPageSize, cat_id,)
             clips_title = LanguageHelper.get_localized_string(LanguageHelper.Clips)
             clips = MediaItem(clips_title, url)
-            clips.icon = self.icon
-            clips.thumb = self.parentItem.thumb
-            clips.fanart = self.parentItem.fanart
             clips.complete = True
             items.append(clips)
 
@@ -426,10 +421,6 @@ class Channel(chn_class.Channel):
             # create a group item
             more_title = LanguageHelper.get_localized_string(LanguageHelper.MorePages)
             more = MediaItem(more_title, "")
-            more.icon = self.icon
-            more.thumb = self.noImage
-            more.thumb = self.parentItem.thumb
-            more.fanart = self.parentItem.fanart
             more.complete = True
             items.append(more)
 
@@ -447,10 +438,6 @@ class Channel(chn_class.Channel):
                 url = current_url.replace("%s1" % (needle, ), "%s%s" % (needle, current_page))
                 Logger.debug("Adding next page: %s\n%s", current_page, url)
                 page = MediaItem(str(current_page), url)
-                page.icon = self.icon
-                page.thumb = self.noImage
-                page.thumb = self.parentItem.thumb
-                page.fanart = self.parentItem.fanart
                 page.type = "page"
                 page.complete = True
 
@@ -557,7 +544,6 @@ class Channel(chn_class.Channel):
 
         item.type = "video"
         item.complete = False
-        item.icon = self.icon
         item.isGeoLocked = result_set["is_geo_restricted"]
         item.isDrmProtected = result_set["is_drm_protected"]
         item.isLive = result_set.get("is_live", False)
@@ -591,7 +577,6 @@ class Channel(chn_class.Channel):
               "&fl=nid,name,program_image,category,logo,is_premium" \
               "&per_page=1000&is_active=true&start=0" % (cat, )
         item = MediaItem(result_set['name'], url)
-        item.thumb = self.noImage
         item.type = 'folder'
         item.complete = True
         return item

--- a/channels/channel.se/urplay/chn_urplay.py
+++ b/channels/channel.se/urplay/chn_urplay.py
@@ -174,9 +174,7 @@ class Channel(chn_class.Channel):
         for cat in categories:
             title = "\a.: {} :.".format(LanguageHelper.get_localized_string(cat))
             item = MediaItem(title, categories[cat])
-            item.thumb = self.noImage
             item.complete = True
-            item.icon = self.icon
             item.dontGroup = True
             items.append(item)
 
@@ -274,7 +272,6 @@ class Channel(chn_class.Channel):
         item.thumb = thumb
         item.description = result_set.get("description")
         item.fanart = fanart
-        item.icon = self.icon
         return item
 
     def create_video_item_json(self, result_set):
@@ -312,11 +309,9 @@ class Channel(chn_class.Channel):
 
         item = MediaItem(title, url)
         item.type = "video"
-        item.icon = self.icon
         item.description = result_set['description']
         item.complete = False
 
-        item.fanart = self.parentItem.fanart
         images = result_set["image"]
         thumb_fanart = None
         for dimension, url in images.items():

--- a/channels/channel.streams/24classic/chn_24classic.py
+++ b/channels/channel.streams/24classic/chn_24classic.py
@@ -106,7 +106,6 @@ class Channel(chn_class.Channel):
               "r=default&page=luister&serial=&subserial=&hook=%s" % (result_set["hook"],)
 
         item = MediaItem(title, url)
-        item.icon = self.icon
         item.thumb = thumb
         item.description = "%s\n\n%s" % (description_nl, description)
         item.description = item.description.strip()
@@ -137,11 +136,9 @@ class Channel(chn_class.Channel):
         url = "https://www.24classics.com/app/ajax/auth.php?serial=%(serial)s" % result_set
 
         item = MediaItem(title, url)
-        item.icon = self.icon
         item.type = "video"
         # seems to not really work well with track numbers (not showing)
         # item.type = "audio"
-        item.thumb = self.parentItem.thumb
         item.complete = False
         item.description = "Composers: %(composers)s\nPerformers: %(performers)s" % result_set
         item.set_info_label("TrackNumber", result_set["order"])

--- a/channels/channel.streams/radio538/chn_radio538.py
+++ b/channels/channel.streams/radio538/chn_radio538.py
@@ -114,8 +114,6 @@ class Channel(chn_class.Channel):
             # "&_=1483280915489%%02d%%02d%%02d"
             title = "Afleveringen van %02d-%02d-%02d" % (current.year, current.month, current.day)
             date_item = MediaItem(title, url)
-            date_item.icon = self.icon
-            date_item.thumb = self.noImage
             date_item.complete = True
             items.append(date_item)
             current = current + datetime.timedelta(1)
@@ -141,8 +139,6 @@ class Channel(chn_class.Channel):
 
         # add live stuff
         live = MediaItem("\bLive streams", self.__liveUrl)
-        live.icon = self.icon
-        live.thumb = self.noImage
         live.complete = True
         live.HttpHeaders = self.__authenticationHeaders
         items = [live]
@@ -168,8 +164,6 @@ class Channel(chn_class.Channel):
         items = []
 
         slam = MediaItem("Slam! TV", "https://hls.slam.nl/streaming/hls/SLAM!/playlist.m3u8")
-        slam.icon = self.icon
-        slam.thumb = self.noImage
         slam.type = "video"
         slam.isLive = True
         items.append(slam)
@@ -177,8 +171,6 @@ class Channel(chn_class.Channel):
         slam_fm = MediaItem("Slam! FM", "https://18973.live.streamtheworld.com/SLAM_AAC.aac"
                                         "?ttag=PLAYER%3ANOPREROLL&tdsdk=js-2.9"
                                         "&pname=TDSdk&pversion=2.9&banners=none")
-        slam_fm.icon = self.icon
-        slam_fm.thumb = self.noImage
         slam_fm.type = "audio"
         slam_fm.isLive = True
         slam_fm.append_single_stream(slam_fm.url)
@@ -283,13 +275,11 @@ class Channel(chn_class.Channel):
         item = MediaItem(title, "", type="video")
         item.description = result_set.get("description")
 
-        item.thumb = self.noImage
         if "image" in result_set:
             if not item.description:
                 item.description = result_set["image"].get("alt", None)
             item.thumb = "https://static.538.nl/%s" % (result_set["image"]['src'],)
 
-        item.icon = self.icon
         item.set_date(*start_time_stamp[0:6])
         item.description = result_set.get('description')
         if "playbackUrls" in result_set and result_set["playbackUrls"]:

--- a/channels/channel.uk/bbc/chn_bbc.py
+++ b/channels/channel.uk/bbc/chn_bbc.py
@@ -388,8 +388,6 @@ class Channel(chn_class.Channel):
 
         extra = MediaItem("Shows (A-Z)", "#alphalisting")
         extra.complete = True
-        extra.icon = self.icon
-        extra.thumb = self.noImage
         extra.description = "Alphabetical show listing of BBC shows"
         extra.dontGroup = True
         items.append(extra)
@@ -418,8 +416,6 @@ class Channel(chn_class.Channel):
                 char = "0-9"
             sub_item = MediaItem(title_format % (char.upper(),), url_format % (char,))
             sub_item.complete = True
-            sub_item.icon = self.icon
-            sub_item.thumb = self.noImage
             sub_item.dontGroup = True
             sub_item.HttpHeaders = {"X-Requested-With": "XMLHttpRequest"}
             items.append(sub_item)

--- a/channels/channel.videos/amt/chn_amt.py
+++ b/channels/channel.videos/amt/chn_amt.py
@@ -78,7 +78,6 @@ class Channel(chn_class.Channel):
 
         # dummy class
         item = MediaItem(title, url)
-        item.icon = self.icon
         item.thumb = thumb_url.replace("poster.jpg", "poster-xlarge.jpg")
         item.fanart = fanart
         item.set_date(year, month, day)
@@ -154,11 +153,9 @@ class Channel(chn_class.Channel):
         thumb = result_set["thumb"]
         year, month, day = result_set["posted"].split("-")
         item = MediaItem(title, self.parentItem.url)
-        item.icon = self.icon
         item.description = self.parentItem.description
         item.type = 'video'
         item.thumb = thumb
-        item.fanart = self.parentItem.fanart
         item.set_date(year, month, day)
 
         runtime = result_set.get("runtime").split(":")

--- a/channels/channel.videos/channel9/chn_channel9.py
+++ b/channels/channel.videos/channel9/chn_channel9.py
@@ -85,7 +85,6 @@ class Channel(chn_class.Channel):
             url = "%s?sort=atoz" % (url,)
 
         item = MediaItem(name, url)
-        item.icon = self.icon
         item.complete = True
         return item
 
@@ -158,7 +157,6 @@ class Channel(chn_class.Channel):
             url = parse.urljoin(self.baseUrl, HtmlEntityHelper.convert_html_entities(result_set[3]))
             name = "\a.: %s :." % (result_set[4],)
             item = MediaItem(name, url)
-            item.thumb = self.noImage
             item.complete = True
             item.type = "folder"
             return item
@@ -170,7 +168,6 @@ class Channel(chn_class.Channel):
         description = helper.get_tag_content("div", {'class': 'description'})
 
         item = MediaItem(name, "%s/RSS" % (url,))
-        item.thumb = self.noImage
         item.type = 'folder'
         item.description = description.strip()
 
@@ -226,8 +223,6 @@ class Channel(chn_class.Channel):
         item.type = 'video'
         item.complete = False
         item.description = description
-        item.thumb = self.noImage
-        item.icon = self.icon
 
         date = xml_data.get_single_node_content("pubDate")
         date_result = Regexer.do_regex(r"\w+, (\d+) (\w+) (\d+)", date)[-1]

--- a/channels/channel.videos/dumpert/chn_dumpert.py
+++ b/channels/channel.videos/dumpert/chn_dumpert.py
@@ -61,16 +61,13 @@ class Channel(chn_class.Channel):
 
         for page in range(0, 2):
             item = MediaItem("Toppertjes - Pagina %s" % (page + 1, ), url_pattern % ('toppers', page))
-            item.icon = self.icon
             items.append(item)
 
         for page in range(0, 10):
             item = MediaItem("Filmpjes - Pagina %s" % (page + 1, ), url_pattern % ('latest', page))
-            item.icon = self.icon
             items.append(item)
 
         item = MediaItem("Zoeken", "searchSite")
-        item.icon = self.icon
         items.append(item)
 
         return data, items

--- a/channels/channel.videos/eredivisie/chn_eredivisie.py
+++ b/channels/channel.videos/eredivisie/chn_eredivisie.py
@@ -102,8 +102,6 @@ class Channel(chn_class.Channel):
 
         url = "%s/%s/%s" % (current_page[0], int(current_page[1]) + 1, current_page[2])
         page_item = MediaItem(LanguageHelper.get_localized_string(LanguageHelper.MorePages), url)
-        page_item.fanart = self.parentItem.fanart
-        page_item.thumb = self.parentItem.thumb
         page_item.dontGroup = True
         items.append(page_item)
 
@@ -139,8 +137,6 @@ class Channel(chn_class.Channel):
             title = "%s%s" % (title[0].upper(), title[1:])
         item = MediaItem(title, url)
         item.complete = True
-        item.thumb = self.noImage
-        item.fanart = self.fanart
         return item
 
     def create_video_item(self, result_set):
@@ -169,10 +165,6 @@ class Channel(chn_class.Channel):
         item.type = "video"
         item.thumb = result_set["Thumb"]
         item.complete = False
-        if self.parentItem is None:
-            item.fanart = self.fanart
-        else:
-            item.fanart = self.parentItem.fanart
         return item
 
     def update_video_item(self, item):

--- a/channels/channel.videos/extreme/chn_extreme.py
+++ b/channels/channel.videos/extreme/chn_extreme.py
@@ -61,7 +61,6 @@ class Channel(chn_class.Channel):
         """
 
         item = MediaItem(result_set[1], "%s%s?page=1" % (self.baseUrl, result_set[0]))
-        item.icon = self.icon
         item.complete = True
         return item
 

--- a/channels/channel.videos/hardwareinfo/chn_hardwareinfo.py
+++ b/channels/channel.videos/hardwareinfo/chn_hardwareinfo.py
@@ -110,8 +110,6 @@ class Channel(chn_class.Channel):
         title = "Hardware Info TV %04d-%04d" % (result_set[0], result_set[0] + result_set[1])
         item = MediaItem(title, url)
         item.complete = True
-        item.icon = self.icon
-        item.thumb = self.noImage
         return item
 
     def create_video_item(self, result_set):
@@ -146,7 +144,6 @@ class Channel(chn_class.Channel):
         url = "http://www.youtube.com/watch?v=%s" % (video_id, )
 
         item = MediaItem(title, url)
-        item.icon = self.icon
         item.type = 'video'
 
         # date stuff
@@ -168,8 +165,6 @@ class Channel(chn_class.Channel):
         # <media:thumbnail url="http://i.ytimg.com/vi/5sTMRR0_Wo8/0.jpg" height="360" width="480" time="00:09:52.500" xmlns:media="http://search.yahoo.com/mrss/" />
         if thumb_url != "":
             item.thumb = thumb_url
-        else:
-            item.thumb = self.noImage
 
         # finish up
         item.complete = False
@@ -203,7 +198,6 @@ class Channel(chn_class.Channel):
         Logger.trace(url)
 
         item = MediaItem(title, url)
-        item.icon = self.icon
         item.type = 'video'
 
         # date stuff
@@ -214,12 +208,11 @@ class Channel(chn_class.Channel):
         Logger.trace("%s-%s-%s %s:%s", year, month, day, hour, minute)
         item.set_date(year, month, day, hour, minute, 0)
 
-        # # description stuff
+        # description stuff
         description = xml_data.get_single_node_content("description")
         item.description = description
 
-        # # thumbnail stuff
-        item.thumb = self.noImage
+        # thumbnail stuff
         thumb_urls = xml_data.get_tag_attribute("enclosure", {'url': None}, {'type': 'image/jpg'}, firstOnly=False)
         for thumb_url in thumb_urls:
             if thumb_url != "" and "thumb" not in thumb_url:

--- a/channels/channel.videos/pathenl/chn_pathenl.py
+++ b/channels/channel.videos/pathenl/chn_pathenl.py
@@ -91,13 +91,11 @@ class Channel(chn_class.Channel):
 
         Logger.trace(result_set)
         cinema = MediaItem(result_set["name"], "")
-        cinema.icon = self.icon
         cinema.thumb = result_set["image"].replace("nocropthumb/[format]/", "")
         cinema.complete = True
 
         now_playing_url = "%s/cinemas/%s/movies/nowplaying" % (self.baseUrl, result_set["id"])
         now_playing = MediaItem("Trailers", now_playing_url)
-        now_playing.icon = self.icon
         # https://www.pathe.nl/nocropthumb/[format]/gfx_content/bioscoop/foto/pathe.nl_380x218px_amersfoort.jpg
         now_playing.complete = True
         now_playing.HttpHeaders = self.httpHeaders
@@ -109,7 +107,6 @@ class Channel(chn_class.Channel):
             title = "%s-%02d-%02d" % (date.year, date.month, date.day)
             schedule_url = "%s/cinemas/%s/schedules?date=%s" % (self.baseUrl, result_set["id"], title)
             schedule = MediaItem("Agenda: %s" % (title,), schedule_url)
-            schedule.icon = self.icon
             schedule.complete = True
             schedule.thumb = cinema.thumb
             schedule.HttpHeaders = self.httpHeaders
@@ -134,7 +131,6 @@ class Channel(chn_class.Channel):
         movie_id = result_set['id']
         url = "%s/movies/%s" % (self.baseUrl, movie_id)
         item = MediaItem(result_set["name"], url)
-        item.icon = self.icon
         item.thumb = result_set["thumb"].replace("nocropthumb/[format]/", "")
         item.complete = True
         item.HttpHeaders = self.httpHeaders
@@ -196,7 +192,6 @@ class Channel(chn_class.Channel):
         Logger.trace(result_set)
         url = self.parentItem.url
         item = MediaItem(result_set["caption"], url, "video")
-        item.icon = self.icon
         item.thumb = result_set["still"].replace("nocropthumb/[format]/", "")
         item.fanart = item.thumb
         item.append_single_stream(result_set['filename'])
@@ -243,8 +238,6 @@ class Channel(chn_class.Channel):
         """
 
         item = MediaItem(result_set[1], result_set[0])
-        item.icon = self.icon
-        item.thumb = self.noImage
         item.complete = True
         return item
 
@@ -271,8 +264,6 @@ class Channel(chn_class.Channel):
         name = result_set[4]
 
         item = MediaItem(name.title(), url)
-        item.thumb = self.noImage
-        item.icon = self.icon
 
         day = result_set[0]
         month = result_set[1]
@@ -320,7 +311,6 @@ class Channel(chn_class.Channel):
 
         item = MediaItem(name, url)
         item.thumb = thumb_url
-        item.icon = self.icon
         item.type = 'video'
 
         # more description stuff

--- a/channels/channel.videos/twit/chn_twit.py
+++ b/channels/channel.videos/twit/chn_twit.py
@@ -75,14 +75,10 @@ class Channel(chn_class.Channel):
         items = []
 
         item = MediaItem("\a.: TWiT.TV Live :.", "http://live.twit.tv/")
-        item.thumb = self.noImage
-        item.icon = self.icon
         item.complete = True
 
         playback_item = MediaItem("Play Live", "http://live.twit.tv/")
         playback_item.type = "playlist"
-        playback_item.thumb = self.noImage
-        playback_item.icon = self.icon
         playback_item.isLive = True
         playback_part = playback_item.create_new_empty_media_part()
 
@@ -159,8 +155,6 @@ class Channel(chn_class.Channel):
         if not item.thumb.startswith("http"):
             item.thumb = "%s%s" % (self.baseUrl, item.thumb)
         item.thumb = item.thumb.replace("coverart-small", "coverart")
-
-        item.icon = self.icon
         item.complete = True
         return item
 
@@ -192,9 +186,6 @@ class Channel(chn_class.Channel):
 
         item = MediaItem(name, url)
         item.type = 'video'
-        item.icon = self.icon
-        item.thumb = self.noImage
-
         month = result_set["month"]
         month = DateHelper.get_month_from_name(month, "en", False)
         day = result_set["day"]

--- a/resources/data/settings_template.xml
+++ b/resources/data/settings_template.xml
@@ -61,6 +61,7 @@
         <setting id="empty_folder" type="select" label="30075" default="2" lvalues="30076|30077|30078" />
         <setting id="folder_prefix" type="text" label="30043" default="" />
         <setting id="hide_fanart" type="bool" label="30086" default="false" />
+        <setting id="use_thumbs_as_fanart" type="bool" label="30088" default="false" />
         <setting id="ignore_ssl_errors" type="bool" label="30569" default="false" />
         <setting id="http_cache" type="bool" label="30031" default="true" />
         <setting id="release_channel" label="30004" type="enum" lvalues="30005|30006" default="0" />

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -342,7 +342,9 @@ msgctxt "#30087"
 msgid "Mix folders and streams while sorting"
 msgstr ""
 
-# empty string with id 30088
+msgctxt "#30088"
+msgid "Show thumbnail as fanart if no fanart is available"
+msgstr ""
 
 msgctxt "#30089"
 msgid "Password Vault"

--- a/resources/language/resource.language.fi_fi/strings.po
+++ b/resources/language/resource.language.fi_fi/strings.po
@@ -268,10 +268,6 @@ msgctxt "#30087"
 msgid "Mix folders and streams while sorting"
 msgstr "Näytä kansiot ja striimit lajiteltuna"
 
-msgctxt "#30088"
-msgid "Finnish"
-msgstr "Suomi"
-
 msgctxt "#30089"
 msgid "Password Vault"
 msgstr "Password Vault"

--- a/resources/language/resource.language.nb_no/strings.po
+++ b/resources/language/resource.language.nb_no/strings.po
@@ -268,10 +268,6 @@ msgctxt "#30087"
 msgid "Mix folders and streams while sorting"
 msgstr "Bland mapper og strømmer mens du sorterer"
 
-msgctxt "#30088"
-msgid "Finnish"
-msgstr "Avslutt"
-
 msgctxt "#30089"
 msgid "Password Vault"
 msgstr "Passord hvelv"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -343,8 +343,8 @@ msgid "Mix folders and streams while sorting"
 msgstr "Mix folders en streams bij het sorteren"
 
 msgctxt "#30088"
-msgid "Finnish"
-msgstr "Fins"
+msgid "Show thumbnail as fanart if no fanart is available"
+msgstr "Gebruik thumbnails als fanart indien er geen fanart aanwezig is"
 
 msgctxt "#30089"
 msgid "Password Vault"

--- a/resources/language/resource.language.sv_se/strings.po
+++ b/resources/language/resource.language.sv_se/strings.po
@@ -344,8 +344,8 @@ msgid "Mix folders and streams while sorting"
 msgstr "Blanda mappar och strömmar vid sorteringen"
 
 msgctxt "#30088"
-msgid "Finnish"
-msgstr "Finska"
+msgid "Show thumbnail as fanart if no fanart is available"
+msgstr "Visa miniatyrbild som fanart om ingen fanart är tillgänglig"
 
 msgctxt "#30089"
 msgid "Password Vault"

--- a/resources/lib/addonsettings.py
+++ b/resources/lib/addonsettings.py
@@ -278,6 +278,17 @@ class AddonSettings(object):
         return AddonSettings.store(KODI).get_boolean_setting("hide_fanart")
 
     @staticmethod
+    def use_thumbs_as_fanart():
+        """ Should we show thumbs if fanart is missing?
+
+        :rtype: bool
+        :return: indicator if we should show thumbs as fanart.
+
+        """
+
+        return AddonSettings.store(KODI).get_boolean_setting("use_thumbs_as_fanart", False)
+
+    @staticmethod
     def hide_drm_items():
         """ Returns whether or not to hide DRM protected items.
 

--- a/resources/lib/chn_class.py
+++ b/resources/lib/chn_class.py
@@ -140,8 +140,6 @@ class Channel:
         Logger.debug("Initializing channel (init_channel): %s", self)
 
         # Make sure all images are from the correct absolute location
-        # self.icon = self.get_image_location(self.icon) -> already in the __init__
-        # self.fanart = self.get_image_location(self.fanart) -> already in the __init__
         self.noImage = TextureHandler.instance().get_texture_uri(self, self.noImage)
         return
 
@@ -362,7 +360,6 @@ class Channel:
                         item = MediaItem(title_format.replace("'", "") % (char,), "")
                     else:
                         item = MediaItem(title_format % (char.upper(),), "")
-                    item.thumb = self.noImage
                     item.complete = True
                     # item.set_date(2100 + ord(char[0]), 1, 1, text='')
                     result[char] = item
@@ -436,7 +433,6 @@ class Channel:
         items = []
         if url is None:
             item = MediaItem("Search Not Implented", "", type='video')
-            item.icon = self.icon
             items.append(item)
         else:
             items = []
@@ -487,9 +483,7 @@ class Channel:
         item = MediaItem(title, url)
         item.thumb = result_set.get("thumburl", None)
         item.description = result_set.get("description", "")
-        item.icon = self.icon
         item.complete = True
-        item.fanart = self.fanart
         item.HttpHeaders = self.httpHeaders
         return item
 
@@ -543,7 +537,6 @@ class Channel:
             item = MediaItem("0", "")
 
         item.type = "page"
-        item.fanart = self.fanart
         item.HttpHeaders = self.httpHeaders
 
         Logger.debug("Created '%s' for url %s", item.name, item.url)
@@ -585,9 +578,7 @@ class Channel:
         item = MediaItem(title, url)
         item.description = result_set.get("description", "")
         item.thumb = result_set.get("thumburl", "")
-        item.icon = self.icon
         item.type = 'folder'
-        item.fanart = self.fanart
         item.HttpHeaders = self.httpHeaders
         item.complete = True
         return item
@@ -637,9 +628,7 @@ class Channel:
         item = MediaItem(title, url)
         item.thumb = self._prefix_urls(result_set.get("thumburl", ""))
         item.description = result_set.get("description", "")
-        item.icon = self.icon
         item.type = 'video'
-        item.fanart = self.fanart
         item.HttpHeaders = self.httpHeaders
         item.complete = False
         return item
@@ -679,7 +668,6 @@ class Channel:
         if not item.thumb and self.noImage:
             # no thumb was set yet and no url
             Logger.debug("Setting thumb to %s", item.thumb)
-            item.thumb = self.noImage
 
         if not item.has_media_item_parts():
             item.complete = False

--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -761,17 +761,6 @@ class Plugin(ParameterParser):
         elif behaviour == "dummy" and not favs:
             # We should add a dummy items, but not for favs
             empty_list_item = MediaItem("- %s -" % (title.strip("."), ), "", type='video')
-            if self.channelObject:
-                empty_list_item.icon = self.channelObject.icon
-                empty_list_item.thumb = self.channelObject.noImage
-                empty_list_item.fanart = self.channelObject.fanart
-            else:
-                icon = Config.icon
-                fanart = Config.fanart
-                empty_list_item.icon = icon
-                empty_list_item.thumb = fanart
-                empty_list_item.fanart = fanart
-
             empty_list_item.dontGroup = True
             empty_list_item.description = "This listing was left empty intentionally."
             empty_list_item.complete = True

--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -412,16 +412,8 @@ class Plugin(ParameterParser):
 
             kodi_items = []
 
-            if self.channelObject:
-                fallback_icon = self.channelObject.noImage
-                fallback_fanart = self.channelObject.fanart
-            else:
-                fallback_icon = Config.icon
-                fallback_fanart = Config.fanart
-
             for media_item in media_items:  # type: MediaItem
-                media_item.thumb = media_item.thumb or fallback_icon
-                media_item.fanart = media_item.fanart or fallback_fanart
+                self.__update_artwork(media_item, self.channelObject)
 
                 if media_item.type == 'folder' or media_item.type == 'append' or media_item.type == "page":
                     action = self.actionListFolder
@@ -969,3 +961,43 @@ class Plugin(ParameterParser):
             play_list.add(current_play_list_items[i].getfilename(), current_play_list_items[i])
 
         return start_url
+
+    def __update_artwork(self, media_item, channel):
+        """ Updates the fanart and icon of a MediaItem if thoses are missing.
+
+        :param MediaItem media_item:    The item to update
+        :param Channel channel:         A possible selected channel
+
+        """
+
+        if media_item is None:
+            return
+
+        if channel:
+            # take the channel values
+            fallback_icon = self.channelObject.icon
+            fallback_thumb = self.channelObject.noImage
+            fallback_fanart = self.channelObject.fanart
+            parent_item = channel.parentItem
+        else:
+            # else the Retrospect ones
+            fallback_icon = Config.icon
+            fallback_thumb = Config.fanart
+            fallback_fanart = Config.fanart
+            parent_item = None
+
+        if parent_item is not None:
+            fallback_thumb = parent_item.thumb or fallback_thumb
+            fallback_fanart = parent_item.fanart or fallback_fanart
+
+        # keep it or use the fallback
+        media_item.icon = media_item.icon or fallback_icon
+        media_item.thumb = media_item.thumb or fallback_thumb
+        media_item.fanart = media_item.fanart or fallback_fanart
+
+        if AddonSettings.use_thumbs_as_fanart() and \
+                TextureHandler.instance().is_texture_or_empty(media_item.fanart) and \
+                not TextureHandler.instance().is_texture_or_empty(media_item.thumb):
+            media_item.fanart = media_item.thumb
+
+        return

--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -762,7 +762,6 @@ class Plugin(ParameterParser):
             # We should add a dummy items, but not for favs
             empty_list_item = MediaItem("- %s -" % (title.strip("."), ), "", type='video')
             empty_list_item.dontGroup = True
-            empty_list_item.description = "This listing was left empty intentionally."
             empty_list_item.complete = True
             # add funny stream here?
             # part = empty_list_item.create_new_empty_media_part()

--- a/resources/lib/textures/__init__.py
+++ b/resources/lib/textures/__init__.py
@@ -120,7 +120,7 @@ class TextureHandler:
         # Should be implemented
         pass
 
-    def is_texture(self, uri):
+    def is_texture_or_empty(self, uri):
         """ Returns whether the uri points to a local resource or remote
 
         :param str uri: The URI for the texture

--- a/resources/lib/textures/__init__.py
+++ b/resources/lib/textures/__init__.py
@@ -32,6 +32,13 @@ class TextureHandler:
 
     @staticmethod
     def instance():
+        """ Returns the TextureHandler singleton
+
+        :return: The TextureHandler
+        :rtype: TextureHandler
+
+        """
+
         return TextureHandler.__TextureHandler
 
     @staticmethod
@@ -112,6 +119,18 @@ class TextureHandler:
 
         # Should be implemented
         pass
+
+    def is_texture(self, uri):
+        """ Returns whether the uri points to a local resource or remote
+
+        :param str uri: The URI for the texture
+
+        :returns: Indicator whether or not the resource is local
+        :rtype: bool
+
+        """
+
+        raise NotImplementedError
 
     def _get_cdn_sub_folder(self, channel):
         """ Determines the CDN folder, e.g.: channel.be.canvas

--- a/resources/lib/textures/cached.py
+++ b/resources/lib/textures/cached.py
@@ -189,6 +189,21 @@ class Cached(TextureHandler):
 
         return
 
+    def is_texture(self, uri):
+        """ Returns whether the uri points to a local resource or remote
+
+        :param str uri: The URI for the texture
+
+        :returns: Indicator whether or not the resource is local
+        :rtype: bool
+
+        """
+
+        if not uri:
+            return True
+
+        return uri.startswith("special://")
+
     def __fetch_texture(self, uri, texture_path):
         """ Fetches a texture
 

--- a/resources/lib/textures/cached.py
+++ b/resources/lib/textures/cached.py
@@ -189,7 +189,7 @@ class Cached(TextureHandler):
 
         return
 
-    def is_texture(self, uri):
+    def is_texture_or_empty(self, uri):
         """ Returns whether the uri points to a local resource or remote
 
         :param str uri: The URI for the texture

--- a/resources/lib/textures/local.py
+++ b/resources/lib/textures/local.py
@@ -32,3 +32,18 @@ class Local(TextureHandler):
 
         self._logger.trace("Resolved texture '%s' to '%s'", file_name, return_value)
         return return_value
+
+    def is_texture(self, uri):
+        """ Returns whether the uri points to a local resource or remote
+
+        :param str uri: The URI for the texture
+
+        :returns: Indicator whether or not the resource is local
+        :rtype: bool
+
+        """
+
+        if not uri:
+            return True
+
+        return not uri.startswith("http://") and not uri.startswith("https://")

--- a/resources/lib/textures/local.py
+++ b/resources/lib/textures/local.py
@@ -33,7 +33,7 @@ class Local(TextureHandler):
         self._logger.trace("Resolved texture '%s' to '%s'", file_name, return_value)
         return return_value
 
-    def is_texture(self, uri):
+    def is_texture_or_empty(self, uri):
         """ Returns whether the uri points to a local resource or remote
 
         :param str uri: The URI for the texture

--- a/resources/lib/textures/remote.py
+++ b/resources/lib/textures/remote.py
@@ -43,3 +43,18 @@ class Remote(TextureHandler):
 
         self._logger.debug("Resolved texture '%s' to '%s'", file_name, return_value)
         return return_value
+
+    def is_texture(self, uri):
+        """ Returns whether the uri points to a local resource or remote
+
+        :param str uri: The URI for the texture
+
+        :returns: Indicator whether or not the resource is local
+        :rtype: bool
+
+        """
+
+        if not uri:
+            return True
+
+        return uri.startswith(self.__cdnUrl)

--- a/resources/lib/textures/remote.py
+++ b/resources/lib/textures/remote.py
@@ -44,7 +44,7 @@ class Remote(TextureHandler):
         self._logger.debug("Resolved texture '%s' to '%s'", file_name, return_value)
         return return_value
 
-    def is_texture(self, uri):
+    def is_texture_or_empty(self, uri):
         """ Returns whether the uri points to a local resource or remote
 
         :param str uri: The URI for the texture

--- a/resources/lib/textures/resourceaddon.py
+++ b/resources/lib/textures/resourceaddon.py
@@ -32,5 +32,20 @@ class Resources(TextureHandler):
         self._logger.debug("Resolved texture '%s' to '%s'", file_name, return_value)
         return return_value
 
+    def is_texture(self, uri):
+        """ Returns whether the uri points to a local resource or remote
+
+        :param str uri: The URI for the texture
+
+        :returns: Indicator whether or not the resource is local
+        :rtype: bool
+
+        """
+
+        if not uri:
+            return True
+
+        return uri.startswith("resource://")
+
     def purge_texture_cache(self, channel):
         TextureHandler.purge_texture_cache(self, channel)

--- a/resources/lib/textures/resourceaddon.py
+++ b/resources/lib/textures/resourceaddon.py
@@ -32,7 +32,7 @@ class Resources(TextureHandler):
         self._logger.debug("Resolved texture '%s' to '%s'", file_name, return_value)
         return return_value
 
-    def is_texture(self, uri):
+    def is_texture_or_empty(self, uri):
         """ Returns whether the uri points to a local resource or remote
 
         :param str uri: The URI for the texture

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -90,6 +90,7 @@
         <setting id="empty_folder" type="select" label="30075" default="2" lvalues="30076|30077|30078" />
         <setting id="folder_prefix" type="text" label="30043" default="" />
         <setting id="hide_fanart" type="bool" label="30086" default="false" />
+        <setting id="use_thumbs_as_fanart" type="bool" label="30088" default="false" />
         <setting id="ignore_ssl_errors" type="bool" label="30569" default="false" />
         <setting id="http_cache" type="bool" label="30031" default="true" />
         <setting id="release_channel" label="30004" type="enum" lvalues="30005|30006" default="0" />


### PR DESCRIPTION
I added an option `Show thumbnail as fanart if no fanart is available` to show thumbs as fanart if the fanart is missing. This is a request of some users that don't like the default channel fanart show for missing fanart.

The resolve order for fanart is now:

| Setting = `False` | Setting = `True` |
|----|----|
| Item fanart | Item fanart |
| Parent fanart | Parent remote fanart  |
| Channel fanart | Item remote thumb |
|  | Channel fanart |

So with the setting to `True`: if the item itself does not have fanart set, it will fallback to the parent's fanart, but only if it is a remote (non-channel) fanart. If the parent only has the local, channel fanart, the thumb of the item will be shown.