### PR TITLE
Make clear that bitrate setting overrides IA

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -93,7 +93,7 @@ msgid "Show DRM/Paid warning before playback"
 msgstr ""
 
 msgctxt "#30020"
-msgid "Maximum Stream Bitrate"
+msgid "Maximum stream bitrate [I][COLOR=gray](overrides IA setting)[/COLOR][/I]"
 msgstr ""
 
 msgctxt "#30021"

--- a/resources/language/resource.language.fi_fi/strings.po
+++ b/resources/language/resource.language.fi_fi/strings.po
@@ -57,7 +57,7 @@ msgid "Show DRM/Paid warning before playback"
 msgstr "Näytä DRM/Maksullinen varoitus ennen toistoa"
 
 msgctxt "#30020"
-msgid "Maximum stream bitrate"
+msgid "Maximum stream bitrate [I][COLOR=gray](overrides IA setting)[/COLOR][/I]"
 msgstr "Toiston maksimi bittinopeus"
 
 msgctxt "#30021"

--- a/resources/language/resource.language.nb_no/strings.po
+++ b/resources/language/resource.language.nb_no/strings.po
@@ -57,7 +57,7 @@ msgid "Show DRM/Paid warning before playback"
 msgstr "Vis advarsel om DRM/Betalt innhold før avspilling"
 
 msgctxt "#30020"
-msgid "Maximum stream bitrate"
+msgid "Maximum stream bitrate [I][COLOR=gray](overrides IA setting)[/COLOR][/I]"
 msgstr "Maksimal strømbitrate"
 
 msgctxt "#30021"

--- a/resources/language/resource.language.nl_nl/strings.po
+++ b/resources/language/resource.language.nl_nl/strings.po
@@ -97,8 +97,8 @@ msgid "Show DRM/Paid warning before playback"
 msgstr "Toon DRM waarschuwing voor het afspelen"
 
 msgctxt "#30020"
-msgid "Maximum Stream Bitrate"
-msgstr "Maximale stream bitrate"
+msgid "Maximum stream bitrate [I][COLOR=gray](overrides IA setting)[/COLOR][/I]"
+msgstr "Maximale stream bitrate [I][COLOR=gray](vervangt de IA instelling)[/COLOR][/I]"
 
 msgctxt "#30021"
 msgid "Enable subtitles by default when available"

--- a/resources/language/resource.language.sv_se/strings.po
+++ b/resources/language/resource.language.sv_se/strings.po
@@ -98,7 +98,7 @@ msgid "Show DRM/Paid warning before playback"
 msgstr "Visa DRM-/betalvarningar innan uppspelning"
 
 msgctxt "#30020"
-msgid "Maximum Stream Bitrate"
+msgid "Maximum stream bitrate [I][COLOR=gray](overrides IA setting)[/COLOR][/I]"
 msgstr "Högsta bithastighet för strömmar"
 
 msgctxt "#30021"


### PR DESCRIPTION
### Functional description
This makes clear that the max bitrate setting overrides the IA setting.

Even better would be to use the new version 1 settings.xml format and add a help text that also explains this affects the stream selection wrt. max resolution.

### Reasoning
This relates to https://github.com/peak3d/inputstream.adaptive/issues/459#issuecomment-640050884