### PR TITLE
Fixed: Regression bug that caused the description prefixes to not be on a new line

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,15 +3,10 @@
 This new version of Retrospect addresses a number of channel bugs. Besides this the behavior of the bitrate limiting was changed and by default no limit is set. Users can still change this via the add-on settings. There was also a fix for changed Kodi Matrix Python API.
 
 [B]Framework related[/B]
-* Fixed: Some Kodi Matrix Python API changes (Fixes #1384)
-* Changed: By default no bitrates are limited. This can be changed via the Retrospect add-on settings
-* Fixed: A bug was introduced to that sometimes sets an empty subtitle to the Kodi player (Fixes #1390)
+_None_
 
 [B]GUI/Settings/Language related[/B]
-* Added: Different color for "Geo-locked" items
+* Fixed: Regression bug that caused the description prefixes to not be on a new line
 
 [B]Channel related[/B]
-* Added: Try to add a geo-locked indicator to NPO Start (See #1380)
-* Fixed: Nick Jr stream resolving (Fixes #1382)
-* Changed: Enabled Dolby Digital audio stream for SVT.se
-* Fixed: NPO Live streams that contain GEO locked content would not play at all (Fixes #1389)
+_None_

--- a/resources/lib/mediaitem.py
+++ b/resources/lib/mediaitem.py
@@ -700,11 +700,11 @@ class MediaItem:
             See https://forum.kodi.tv/showthread.php?tid=210837
             """
 
-            return "".join([text_format.format(clr, text.lstrip()) for clr, text in texts])
+            return "".join([text_format.format(clr, text.lstrip()) for clr, text in texts]).strip()
 
         # actually update it
         if description_prefix:
-            description = __color_text(description_prefix)
+            description = __color_text(description_prefix, text_format="[COLOR {}]{}[/COLOR]\n")
 
         if title_postfix:
             title = __color_text(title_postfix)

--- a/tests/test_urihandler.py
+++ b/tests/test_urihandler.py
@@ -123,6 +123,7 @@ class TestUriHandler(unittest.TestCase):
         self.assertEqual("", url)
         self.assertEqual("", content_type)
 
+    @unittest.skip("Error in httpbin.org causes 404: https://github.com/postmanlabs/httpbin/issues/617")
     def test_head_redirect(self):
         UriHandler.create_uri_handler()
 
@@ -132,6 +133,7 @@ class TestUriHandler(unittest.TestCase):
         self.assertEqual(url, 'http://httpbin.org/get')
         self.assertEqual(200, UriHandler.instance().status.code)
 
+    @unittest.skip("Error in httpbin.org causes 404: https://github.com/postmanlabs/httpbin/issues/617")
     def test_head_double_redirect(self):
         UriHandler.create_uri_handler()
 


### PR DESCRIPTION
Regression bug that caused the description prefixes to not be on a new line

### Functional description
<!--- Give a clear explanation of the change, fix or new feature 
that this PR contains -->
<!--- Put your text below this line -->
Fixes the regression
<!--- Put your text above this line -->