### PR TITLE
Fix timestamp generation for authentication on vier on older Android versions

### DIFF
--- a/channels/channel.be/vier/awsidp.py
+++ b/channels/channel.be/vier/awsidp.py
@@ -3,7 +3,6 @@ import hashlib
 import hmac
 import os
 import binascii
-import sys
 
 import datetime
 
@@ -349,11 +348,7 @@ class AwsIdp:
         days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 
         time_now = datetime.datetime.utcnow()
-        if sys.platform.startswith('win'):
-            format_string = "{} {} %#d %H:%M:%S UTC %Y".format(days[time_now.weekday()], months[time_now.month])
-        else:
-            format_string = "{} {} %-d %H:%M:%S UTC %Y".format(days[time_now.weekday()], months[time_now.month])
-
+        format_string = "{} {} {} %H:%M:%S UTC %Y".format(days[time_now.weekday()], months[time_now.month], time_now.day)
         time_string = datetime.datetime.utcnow().strftime(format_string)
         Logger.debug("AWS Auth Timestamp: %s", time_string)
         return time_string


### PR DESCRIPTION
It seems that some Android devices don't understand the `%-d` syntax of `strftime`, so modifying the date-portion to use the date directly instead of relying on strftime fixes this issue.

### Functional description
Directly insert the date (without padded zero) into the string instead of relying on `strftime` to do this.

### Reasoning
It seems that there is a version of libc (or some other library that is used by python to do its magic) doesn't support `%-d`.

### Technical description
The error returned by AWS IDP is `TIMESTAMP format should be EEE MMM d HH:mm:ss yyyy in english`. The current code will generate this string: `Sat Nov -d 08:48:59 UTC 2020`.

This has been reported on a Android 7.1.2 API level 25, kernel: Linux ARM 32-bit version 3.14.29

See https://github.com/add-ons/plugin.video.viervijfzes/pull/58
