### PR TITLE
Simplify playback of streams

### DIFF
--- a/channels/channel.be/een/chn_een.py
+++ b/channels/channel.be/een/chn_een.py
@@ -177,7 +177,6 @@ class Channel(chn_class.Channel):
         # now the mediaurl is derived. First we try WMV
         data = UriHandler.open(item.url)
 
-        part = item.create_new_empty_media_part()
         if "mediazone.vrt.be" not in item.url:
             # Extract actual media data
             video_id = Regexer.do_regex('data-video=[\'"]([^"\']+)[\'"]', data)[0]
@@ -194,7 +193,7 @@ class Channel(chn_class.Channel):
 
             hls_url = url_info["url"]
             for s, b in M3u8.get_streams_from_m3u8(hls_url):
-                part.append_media_stream(s, b)
+                item.add_stream(s, b)
 
         item.complete = True
         return item

--- a/channels/channel.be/ketnet/chn_ketnet.py
+++ b/channels/channel.be/ketnet/chn_ketnet.py
@@ -201,10 +201,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.be/sporza/chn_sporza.py
+++ b/channels/channel.be/sporza/chn_sporza.py
@@ -255,10 +255,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -283,10 +283,9 @@ class Channel(chn_class.Channel):
             return item
 
         Logger.debug("Found stream url for %s: %s", item, url)
-        part = item.create_new_empty_media_part()
         for s, b in M3u8.get_streams_from_m3u8(url):
             item.complete = True
-            part.append_media_stream(s, b)
+            item.add_stream(s, b)
         return item
 
     def update_video_item(self, item):
@@ -298,10 +297,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -334,7 +333,6 @@ class Channel(chn_class.Channel):
         data = UriHandler.open(item.url)
         data = data.replace("\\/", "/")
         urls = Regexer.do_regex(self.mediaUrlRegex, data)
-        part = item.create_new_empty_media_part()
         for url in urls:
             Logger.trace(url)
             if url[0] == "src":
@@ -362,7 +360,7 @@ class Channel(chn_class.Channel):
 
                     for s, b in M3u8.get_streams_from_m3u8(flv):
                         item.complete = True
-                        part.append_media_stream(s, b)
+                        item.add_stream(s, b)
                     # no need to continue adding the streams
                     continue
 
@@ -374,7 +372,7 @@ class Channel(chn_class.Channel):
                     flv = "%s/%s" % (flv_server, flv_path)
                     bitrate = 0
 
-            part.append_media_stream(flv, bitrate)
+            item.add_stream(flv, bitrate)
 
         item.complete = True
         return item

--- a/channels/channel.be/vier/chn_vier.py
+++ b/channels/channel.be/vier/chn_vier.py
@@ -525,10 +525,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -556,10 +556,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -604,8 +604,7 @@ class Channel(chn_class.Channel):
             # set it for the error statistics
             item.isGeoLocked = True
 
-        part = item.create_new_empty_media_part()
         item.complete = M3u8.update_part_with_m3u8_streams(
-            part, m3u8_url, channel=self, encrypted=False)
+            item, m3u8_url, channel=self, encrypted=False)
 
         return item

--- a/channels/channel.be/vrtnu/chn_vrtnu.py
+++ b/channels/channel.be/vrtnu/chn_vrtnu.py
@@ -582,7 +582,7 @@ class Channel(chn_class.Channel):
         return item
 
     def update_live_video(self, item):
-        """ Updates an existing live stream MediaItem with more data.
+        """ Updates an existing MediaItem with more data.
 
         Used to update none complete MediaItems (self.complete = False). This
         could include opening the item's URL to fetch more data and then process that
@@ -590,10 +590,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -615,10 +615,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.be/vtm/chn_vtm.py
+++ b/channels/channel.be/vtm/chn_vtm.py
@@ -137,10 +137,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.be/vtm/chn_vtm.py
+++ b/channels/channel.be/vtm/chn_vtm.py
@@ -173,7 +173,7 @@ class Channel(chn_class.Channel):
         for stream in streams:
             stream_url = stream['url']
             if stream['type'] == "mp4":
-                item.append_single_stream(stream_url, 0)
+                item.add_stream(stream_url, 0)
                 item.complete = True
 
         return item

--- a/channels/channel.be/vtmbe/chn_vtmbe.py
+++ b/channels/channel.be/vtmbe/chn_vtmbe.py
@@ -868,10 +868,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -893,10 +893,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -1082,16 +1082,16 @@ class Channel(chn_class.Channel):
     def update_video_item(self, item):
         """ Updates an existing MediaItem with more data.
 
-        Used to update none complete MediaItems (self.complete = False). This
+        UUsed to update none complete MediaItems (self.complete = False). This
         could include opening the item's URL to fetch more data and then process that
         data or retrieve it's real media-URL.
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -1121,10 +1121,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.be/vtmbe/chn_vtmbe.py
+++ b/channels/channel.be/vtmbe/chn_vtmbe.py
@@ -1184,8 +1184,7 @@ class Channel(chn_class.Channel):
 
             license_key = license_key[2:]
             license_key = "|Cookie={0}|R{{SSM}}|".format(HtmlEntityHelper.url_encode(license_key))
-            part = item.create_new_empty_media_part()
-            stream = part.append_media_stream(hls, 0)
+            stream = item.add_stream(hls, 0)
             M3u8.set_input_stream_addon_input(stream, license_key=license_key)
             item.complete = True
         else:
@@ -1201,10 +1200,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -1235,7 +1234,7 @@ class Channel(chn_class.Channel):
         for stream in streams:
             stream_url = stream['url']
             if stream['type'] == "mp4":
-                item.append_single_stream(stream_url, 0)
+                item.add_stream(stream_url, 0)
                 item.complete = True
 
         return item
@@ -1252,20 +1251,7 @@ class Channel(chn_class.Channel):
     def __update_video_item(self, item, video_id):
         """ Updates an existing MediaItem with more data.
 
-        Used to update none complete MediaItems (self.complete = False). This
-        could include opening the item's URL to fetch more data and then process that
-        data or retrieve it's real media-URL.
-
-        The method should at least:
-        * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
-        * set self.complete = True.
-
-        if the returned item does not have a MediaItemPart then the self.complete flag
-        will automatically be set back to False.
-
         :param MediaItem item: the original MediaItem that needs updating.
-        :param str video_id: the video ID of the item to update.
 
         :return: The original item with more data added to it's properties.
         :rtype: MediaItem
@@ -1306,8 +1292,7 @@ class Channel(chn_class.Channel):
             license_headers = "x-dt-custom-data={0}&Content-Type=application/octstream".format(base64.b64encode(license_header))
             license_key = "{0}?specConform=true|{1}|R{{SSM}}|".format(license_url, license_headers or "")
 
-            part = item.create_new_empty_media_part()
-            stream = part.append_media_stream(stream_url, 0)
+            stream = item.add_stream(stream_url, 0)
             Mpd.set_input_stream_addon_input(stream, license_key=license_key, license_type="com.widevine.alpha")
             item.complete = True
         else:
@@ -1325,17 +1310,17 @@ class Channel(chn_class.Channel):
                 )
                 return item
 
-            part = item.create_new_empty_media_part()
             # Set the Range header to a proper value to make all streams start at the beginning. Make
             # sure that a complete TS part comes in a single call otherwise we get stuttering.
             byte_range = 10 * 1024 * 1024
             Logger.debug("Setting an 'Range' http header of bytes=0-%d to force playback at the start "
                          "of a stream and to include a full .ts part.", byte_range)
-            part.HttpHeaders["Range"] = 'bytes=0-%d' % (byte_range, )
+            headers = {"Range": 'bytes=0-%d' % (byte_range, )}
 
             for s, b in M3u8.get_streams_from_m3u8(m3u8_url):
                 item.complete = True
-                part.append_media_stream(s, b)
+                stream = item.add_stream(s, b)
+                stream.HttpHeaders.update(headers)
 
         return item
 

--- a/channels/channel.de/srf/chn_srf.py
+++ b/channels/channel.de/srf/chn_srf.py
@@ -157,7 +157,7 @@ class Channel(chn_class.Channel):
         for playback.
 
         :param result_set: The result_set of the self.episodeItemRegex
-        :type result_set: list[str]|dict[str,dict[str,dict]]
+        :type result_set: dict
 
         :return: A new MediaItem of type 'video' or 'audio' (despite the method's name).
         :rtype: MediaItem|None
@@ -277,24 +277,23 @@ class Channel(chn_class.Channel):
         json = JsonHelper(data)
         video_info = json.get_value("content", "videoInfos")
 
-        part = item.create_new_empty_media_part()
         if "HLSurlHD" in video_info:
             # HLSurlHD=http://srfvodhd-vh.akamaihd.net/i/vod/potzmusig/2015/03/
             # potzmusig_20150307_184438_v_webcast_h264_,q10,q20,q30,q40,q50,q60,.mp4.csmil/master.m3u8
             for s, b in M3u8.get_streams_from_m3u8(video_info["HLSurlHD"]):
                 item.complete = True
-                part.append_media_stream(s, b)
+                item.add_stream(s, b)
         elif "HLSurl" in video_info:
             # HLSurl=http://srfvodhd-vh.akamaihd.net/i/vod/potzmusig/2015/03/
             # potzmusig_20150307_184438_v_webcast_h264_,q10,q20,q30,q40,.mp4.csmil/master.m3u8
             for s, b in M3u8.get_streams_from_m3u8(video_info["HLSurl"]):
                 item.complete = True
-                part.append_media_stream(s, b)
+                item.add_stream(s, b)
 
         if "downloadLink" in video_info:
             # downloadLink=http://podcastsource.sf.tv/nps/podcast/10vor10/2015/03/
             # 10vor10_20150304_215030_v_podcast_h264_q10.mp4
-            part.append_media_stream(video_info["downloadLink"], 1000)
+            item.add_stream(video_info["downloadLink"], 1000)
 
         return item
 
@@ -326,7 +325,6 @@ class Channel(chn_class.Channel):
         json = JsonHelper(data)
         video_play_lists = json.get_value("Video", "Playlists", "Playlist")
 
-        part = item.create_new_empty_media_part()
         for play_list in video_play_lists:
             streams = play_list["url"]
             Logger.trace("Found %s streams", len(streams))
@@ -335,30 +333,29 @@ class Channel(chn_class.Channel):
                 if ".m3u8" in stream_url:
                     for s, b in M3u8.get_streams_from_m3u8(stream_url):
                         item.complete = True
-                        part.append_media_stream(s, b)
+                        item.add_stream(s, b)
                 else:
                     Logger.debug("Cannot use stream url: %s", stream_url)
 
         # Unused at the moment
         # videoInfo = json.get_value("content", "videoInfos")
         #
-        # part = item.create_new_empty_media_part()
         # if "HLSurlHD" in videoInfo:
         #     # HLSurlHD=http://srfvodhd-vh.akamaihd.net/i/vod/potzmusig/2015/03/potzmusig_20150307_184438_v_webcast_h264_,q10,q20,q30,q40,q50,q60,.mp4.csmil/master.m3u8
         #     for s, b in M3u8.get_streams_from_m3u8(videoInfo["HLSurlHD"]):
         #         item.complete = True
         #         # s = self.get_verifiable_video_url(s)
-        #         part.append_media_stream(s, b)
+        #         item.add_stream(s, b)
         # elif "HLSurl" in videoInfo:
         #     # HLSurl=http://srfvodhd-vh.akamaihd.net/i/vod/potzmusig/2015/03/potzmusig_20150307_184438_v_webcast_h264_,q10,q20,q30,q40,.mp4.csmil/master.m3u8
         #     for s, b in M3u8.get_streams_from_m3u8(videoInfo["HLSurl"]):
         #         item.complete = True
         #         # s = self.get_verifiable_video_url(s)
-        #         part.append_media_stream(s, b)
+        #         item.add_stream(s, b)
         #
         # if "downloadLink" in videoInfo:
         #     # downloadLink=http://podcastsource.sf.tv/nps/podcast/10vor10/2015/03/10vor10_20150304_215030_v_podcast_h264_q10.mp4
-        #     part.append_media_stream(videoInfo["downloadLink"], 1000)
+        #     item.add_stream(videoInfo["downloadLink"], 1000)
 
         return item
 

--- a/channels/channel.de/srf/chn_srf.py
+++ b/channels/channel.de/srf/chn_srf.py
@@ -258,10 +258,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -306,10 +306,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.mtg/tvse/chn_tvse.py
+++ b/channels/channel.mtg/tvse/chn_tvse.py
@@ -198,9 +198,8 @@ class Channel(chn_class.Channel):
         data = UriHandler.open(item.url)
         m3u8_url = Regexer.do_regex('data-file="([^"]+)"', data)[0]
 
-        part = item.create_new_empty_media_part()
         if AddonSettings.use_adaptive_stream_add_on(with_encryption=False):
-            stream = part.append_media_stream(m3u8_url, 0)
+            stream = item.add_stream(m3u8_url, 0)
             M3u8.set_input_stream_addon_input(stream)
             item.complete = True
         else:
@@ -210,7 +209,7 @@ class Channel(chn_class.Channel):
                     video_part = s.rsplit("-", 1)[-1]
                     video_part = "-%s" % (video_part,)
                     s = a.replace(".m3u8", video_part)
-                part.append_media_stream(s, b)
+                item.add_stream(s, b)
                 item.complete = True
 
         return item

--- a/channels/channel.mtg/tvse/chn_tvse.py
+++ b/channels/channel.mtg/tvse/chn_tvse.py
@@ -182,10 +182,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.mtg/viafree/chn_viafree.py
+++ b/channels/channel.mtg/viafree/chn_viafree.py
@@ -572,10 +572,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -688,11 +688,11 @@ class Channel(chn_class.Channel):
                 item.subtitle = SubtitleHelper.download_subtitle(subs[0], format='webvtt')
         return
 
-    def __update_rtmp(self, url, part, quality):
+    def __update_rtmp(self, url, item, quality):
         """ Update a video that has a RTMP stream.
 
         :param str url:                 The URL for the stream.
-        :param MediaItemPart part:      The new part that needs updating.
+        :param MediaItem item:          The new part that needs updating.
         :param tuple[str,int] quality:  A quality tuple with quality name and bitrate
 
         """
@@ -712,7 +712,7 @@ class Channel(chn_class.Channel):
             Logger.debug("Updated URL from - to:\n%s\n%s", old_url, url)
 
         url = self.get_verifiable_video_url(url)
-        part.append_media_stream(url, quality[1])
+        item.add_stream(url, quality[1])
         return
 
     def __create_json_episode_item(self, result_set, check_channel=True):

--- a/channels/channel.mtg/viafree/chn_viafree.py
+++ b/channels/channel.mtg/viafree/chn_viafree.py
@@ -4,7 +4,7 @@ import datetime
 
 from resources.lib import chn_class, mediatype
 
-from resources.lib.mediaitem import MediaItem, MediaItemPart
+from resources.lib.mediaitem import MediaItem
 from resources.lib.regexer import Regexer
 from resources.lib.logger import Logger
 from resources.lib.urihandler import UriHandler
@@ -317,8 +317,7 @@ class Channel(chn_class.Channel):
             srt = result_set.get("subtitles_webvtt")
         if srt:
             Logger.debug("Storing SRT/WebVTT path: %s", srt)
-            part = item.create_new_empty_media_part()
-            part.Subtitle = srt
+            item.subtitle = srt
         return item
 
     def add_clips(self, data):
@@ -559,8 +558,7 @@ class Channel(chn_class.Channel):
             srt = result_set.get("subtitles_webvtt")
         if srt:
             Logger.debug("Storing SRT/WebVTT path: %s", srt)
-            part = item.create_new_empty_media_part()
-            part.Subtitle = srt
+            item.subtitle = srt
 
         item.set_info_label("duration", int(result_set.get("duration", 0)))
         return item
@@ -588,7 +586,7 @@ class Channel(chn_class.Channel):
         """
 
         Logger.debug('Starting update_video_item for %s (%s)', item.name, self.channelName)
-        use_kodi_hls = AddonSettings.use_adaptive_stream_add_on(channel=self)
+        use_kodi_hls = AddonSettings.use_adaptive_stream_add_on(channel=self) and False
 
         # User-agent (and possible other headers), should be consistent over all
         # M3u8 requests (See #864)
@@ -607,16 +605,11 @@ class Channel(chn_class.Channel):
             return self.__update_embedded(item, embedded_data)
 
         # see if there was an srt already
-        if item.MediaItemParts:
-            part = item.MediaItemParts[0]
-            if part.Subtitle and part.Subtitle.endswith(".vtt"):
-                part.Subtitle = SubtitleHelper.download_subtitle(
-                    part.Subtitle, format="webvtt")
+        if item.subtitle:
+            if item.subtitle.endswith(".vtt"):
+                item.subtitle = SubtitleHelper.download_subtitle(item.subtitle, format="webvtt")
             else:
-                part.Subtitle = SubtitleHelper.download_subtitle(
-                    part.Subtitle, format="dcsubtitle")
-        else:
-            part = item.create_new_empty_media_part()
+                item.subtitle = SubtitleHelper.download_subtitle(item.subtitle, format="dcsubtitle")
 
         for quality in ("high", 3500), ("hls", 2700), ("medium", 2100):
             url = json.get_value("streams", quality[0])
@@ -629,31 +622,33 @@ class Channel(chn_class.Channel):
                 continue
 
             if url.startswith("http") and ".m3u8" in url:
-                self.__update_m3u8(url, part, headers, use_kodi_hls)
+                self.__update_m3u8(url, item, headers, use_kodi_hls)
 
             elif url.startswith("rtmp"):
-                self.__update_rtmp(url, part, quality)
+                self.__update_rtmp(url, item, quality)
 
             elif "[empty]" in url:
                 Logger.debug("Found post-live url with '[empty]' in it. Ignoring this.")
                 continue
 
             else:
-                part.append_media_stream(url, quality[1])
+                item.add_stream(url, quality[1])
 
         if not use_kodi_hls:
-            part.HttpHeaders.update(headers)
+            for stream in item.streams:
+                stream.HttpHeaders.update(headers)
 
-        if part.MediaStreams:
+        if item.has_streams():
             item.complete = True
+
         Logger.trace("Found mediaurl: %s", item)
         return item
 
-    def __update_m3u8(self, url, part, headers, use_kodi_hls):
+    def __update_m3u8(self, url, item, headers, use_kodi_hls):
         """ Update a video that has M3u8 streams.
 
         :param str url:                 The URL for the stream.
-        :param MediaItemPart part:      The new part that needs updating.
+        :param MediaItem item:          The item that needs updating.
         :param dict[str,str] headers:   The URL headers to use.
         :param bool use_kodi_hls:       Should we use the InputStream Adaptive add-on?
 
@@ -661,36 +656,36 @@ class Channel(chn_class.Channel):
         # first see if there are streams in this file, else check the second location.
         for s, b in M3u8.get_streams_from_m3u8(url, headers=headers):
             if use_kodi_hls:
-                strm = part.append_media_stream(url, 0)
+                strm = item.add_stream(url, 0)
                 M3u8.set_input_stream_addon_input(strm, headers=headers)
                 # Only the main M3u8 is needed
                 break
             else:
-                part.append_media_stream(s, b)
+                item.add_stream(s, b)
 
-        if not part.MediaStreams and "manifest.m3u8" in url:
+        if not item.has_streams() and "manifest.m3u8" in url:
             Logger.warning("No streams found in %s, trying alternative with 'master.m3u8'", url)
             url = url.replace("manifest.m3u8", "master.m3u8")
             for s, b in M3u8.get_streams_from_m3u8(url, headers=headers):
                 if use_kodi_hls:
-                    strm = part.append_media_stream(url, 0)
+                    strm = item.add_stream(url, 0)
                     M3u8.set_input_stream_addon_input(strm, headers=headers)
                     # Only the main M3u8 is needed
                     break
                 else:
-                    part.append_media_stream(s, b)
+                    item.add_stream(s, b)
 
         # check for subs
         # https://mtgxse01-vh.akamaihd.net/i/201703/13/DCjOLN_1489416462884_427ff3d3_,48,260,460,900,1800,2800,.mp4.csmil/master.m3u8?__b__=300&hdnts=st=1489687185~exp=3637170832~acl=/*~hmac=d0e12e62c219d96798e5b5ef31b11fa848724516b255897efe9808c8a499308b&cc1=name=Svenska%20f%C3%B6r%20h%C3%B6rselskadade~default=no~forced=no~lang=sv~uri=https%3A%2F%2Fsubstitch.play.mtgx.tv%2Fsubtitle%2Fconvert%2Fxml%3Fsource%3Dhttps%3A%2F%2Fcdn-subtitles-mtgx-tv.akamaized.net%2Fpitcher%2F20xxxxxx%2F2039xxxx%2F203969xx%2F20396967%2F20396967-swt.xml%26output%3Dm3u8
         # https://cdn-subtitles-mtgx-tv.akamaized.net/pitcher/20xxxxxx/2039xxxx/203969xx/20396967/20396967-swt.xml&output=m3u8
-        if "uri=" in url and not part.Subtitle:
+        if "uri=" in url and not item.subtitle:
             Logger.debug("Extracting subs from M3u8")
             sub_url = url.rsplit("uri=")[-1]
             sub_url = HtmlEntityHelper.url_decode(sub_url)
             sub_data = UriHandler.open(sub_url)
             subs = [line for line in sub_data.split("\n") if line.startswith("http")]
             if subs:
-                part.Subtitle = SubtitleHelper.download_subtitle(subs[0], format='webvtt')
+                item.subtitle = SubtitleHelper.download_subtitle(subs[0], format='webvtt')
         return
 
     def __update_rtmp(self, url, part, quality):
@@ -812,8 +807,7 @@ class Channel(chn_class.Channel):
         """
 
         stream_url = embedded_data["prioritizedStreams"][0]["links"]["stream"]["href"]
-        part = item.create_new_empty_media_part()
-        stream = part.append_media_stream(stream_url, 0)
+        stream = item.add_stream(stream_url, 0)
         M3u8.set_input_stream_addon_input(stream)
         item.complete = True
 
@@ -829,6 +823,6 @@ class Channel(chn_class.Channel):
                 continue
             sub_format = subtitle_info.get("data", {}).get("format", "").lower()
             subtitle_url = subtitle_info["link"]["href"]
-            part.Subtitle = SubtitleHelper.download_subtitle(subtitle_url, format=sub_format)
+            item.subtitle = SubtitleHelper.download_subtitle(subtitle_url, format=sub_format)
 
         return item

--- a/channels/channel.mtv/mtvnl/chn_mtvnl.py
+++ b/channels/channel.mtv/mtvnl/chn_mtvnl.py
@@ -304,10 +304,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -341,7 +341,7 @@ class Channel(chn_class.Channel):
             XbmcWrapper.show_dialog(LanguageHelper.ErrorId, error)
             return item
 
-        item.MediaItemParts = []
+        item.streams = []
         item.add_stream(url, 0)
         item.complete = True
         return item

--- a/channels/channel.mtv/mtvnl/chn_mtvnl.py
+++ b/channels/channel.mtv/mtvnl/chn_mtvnl.py
@@ -342,7 +342,6 @@ class Channel(chn_class.Channel):
             return item
 
         item.MediaItemParts = []
-        part = item.create_new_empty_media_part()
-        part.append_media_stream(url, 0)
+        item.add_stream(url, 0)
         item.complete = True
         return item

--- a/channels/channel.mtv/southpark/chn_southpark.py
+++ b/channels/channel.mtv/southpark/chn_southpark.py
@@ -141,10 +141,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -163,7 +163,7 @@ class Channel(chn_class.Channel):
         data = UriHandler.open(item.url)
         guids = Regexer.do_regex(guid_regex, data)
 
-        item.MediaItemParts = []
+        item.streams = []
         for guid in guids:
             # get the info for this part
             Logger.debug("Processing part with GUID: %s", guid)

--- a/channels/channel.mtv/southpark/chn_southpark.py
+++ b/channels/channel.mtv/southpark/chn_southpark.py
@@ -168,9 +168,6 @@ class Channel(chn_class.Channel):
             # get the info for this part
             Logger.debug("Processing part with GUID: %s", guid)
 
-            # reset stuff
-            part = None
-
             # http://www.southpark.nl/feeds/video-player/mediagen?uri=mgid%3Aarc%3Aepisode%3Acomedycentral.com%3Aeb2a53f7-e370-4049-a6a9-57c195367a92&suppressRegisterBeacon=true
             guid = HtmlEntityHelper.url_encode("mgid:arc:episode:comedycentral.com:%s" % (guid,))
             info_url = "%s/feeds/video-player/mediagen?uri=%s&suppressRegisterBeacon=true" % (self.baseUrl, guid)
@@ -180,11 +177,7 @@ class Channel(chn_class.Channel):
             rtmp_streams = Regexer.do_regex(rtmp_regex, info_data)
 
             for rtmp_stream in rtmp_streams:
-                # if this is the first stream for the part, create an new part
-                if part is None:
-                    part = item.create_new_empty_media_part()
-
-                part.append_media_stream(self.get_verifiable_video_url(rtmp_stream[2]), rtmp_stream[1])
+                item.add_stream(self.get_verifiable_video_url(rtmp_stream[2]), rtmp_stream[1])
 
         item.complete = True
         Logger.trace("Media item updated: %s", item)

--- a/channels/channel.nick/nickelodeon/chn_nickelodeon.py
+++ b/channels/channel.nick/nickelodeon/chn_nickelodeon.py
@@ -345,12 +345,11 @@ class Channel(chn_class.Channel):
             stream = JsonHelper(stream_data)
 
             # subUrls = stream.get_value("package", "video", "item", 0, "transcript", 0, "typographic")  # NOSONAR
-            part = item.create_new_empty_media_part()
 
             hls_streams = stream.get_value("package", "video", "item", 0, "rendition")
             for hls_stream in hls_streams:
                 hls_url = hls_stream["src"]
-                item.complete |= M3u8.update_part_with_m3u8_streams(part, hls_url)
+                item.complete |= M3u8.update_part_with_m3u8_streams(item, hls_url)
 
         item.complete = True
         Logger.trace("Media url: %s", item)

--- a/channels/channel.nick/nickelodeon/chn_nickelodeon.py
+++ b/channels/channel.nick/nickelodeon/chn_nickelodeon.py
@@ -320,10 +320,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         """

--- a/channels/channel.nick/nickjr/chn_nickjr.py
+++ b/channels/channel.nick/nickjr/chn_nickjr.py
@@ -254,10 +254,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.nick/nickjr/chn_nickjr.py
+++ b/channels/channel.nick/nickjr/chn_nickjr.py
@@ -282,12 +282,11 @@ class Channel(chn_class.Channel):
             stream = JsonHelper(stream_data)
 
             # subUrls = stream.get_value("package", "video", "item", 0, "transcript", 0, "typographic")  # NOSONAR
-            part = item.create_new_empty_media_part()
 
             hls_streams = stream.get_value("package", "video", "item", 0, "rendition")
             for hls_stream in hls_streams:
                 hls_url = hls_stream["src"]
-                item.complete |= M3u8.update_part_with_m3u8_streams(part, hls_url)
+                item.complete |= M3u8.update_part_with_m3u8_streams(item, hls_url)
 
         item.complete = True
         Logger.trace("Media url: %s", item)

--- a/channels/channel.no/nrkno/chn_nrkno.py
+++ b/channels/channel.no/nrkno/chn_nrkno.py
@@ -581,10 +581,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -615,10 +615,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.no/nrkno/chn_nrkno.py
+++ b/channels/channel.no/nrkno/chn_nrkno.py
@@ -634,12 +634,11 @@ class Channel(chn_class.Channel):
         if not stream_data:
             return item
 
-        part = item.create_new_empty_media_part()
         for stream_info in stream_data["assets"]:
             url = stream_info["url"]
             stream_type = stream_info["format"]
             if stream_type == "HLS":
-                item.complete = M3u8.update_part_with_m3u8_streams(part, url)
+                item.complete = M3u8.update_part_with_m3u8_streams(item, url)
             else:
                 Logger.warning("Found unknow stream type: %s", stream_type)
 
@@ -655,7 +654,7 @@ class Channel(chn_class.Channel):
                 sub_type = "webvtt"  # set Retrospect type
 
             if sub_url:
-                part.Subtitle = SubtitleHelper.download_subtitle(sub_url, format=sub_type)
+                item.subtitle = SubtitleHelper.download_subtitle(sub_url, format=sub_type)
                 break
 
         return item
@@ -677,12 +676,11 @@ class Channel(chn_class.Channel):
         video_info = manifest.get_value("playable", "assets", 0)
         url = video_info["url"]
         # Is it encrypted? encrypted = video_info["encrypted"]
-        part = item.create_new_empty_media_part()
 
         # Adaptive add-on does not work with audio only
         for s, b in M3u8.get_streams_from_m3u8(url):
             item.complete = True
-            part.append_media_stream(s, b)
+            item.add_stream(s, b)
 
         return item
 
@@ -690,27 +688,26 @@ class Channel(chn_class.Channel):
         video_info = manifest.get_value("playable", "assets", 0)
         url = video_info["url"]
         encrypted = video_info["encrypted"]
-        part = item.create_new_empty_media_part()
 
         if encrypted:
             use_adaptive = AddonSettings.use_adaptive_stream_add_on(with_encryption=True)
             if not use_adaptive:
                 Logger.error("Cannot playback encrypted item without inputstream.adaptive with encryption support")
                 return item
-            stream = part.append_media_stream(url, 0)
+            stream = item.add_stream(url, 0)
             key = M3u8.get_license_key("", key_type="R")
             M3u8.set_input_stream_addon_input(stream, license_key=key)
             item.complete = True
         else:
             use_adaptive = AddonSettings.use_adaptive_stream_add_on(with_encryption=False)
             if use_adaptive:
-                stream = part.append_media_stream(url, 0)
+                stream = item.add_stream(url, 0)
                 M3u8.set_input_stream_addon_input(stream)
                 item.complete = True
             else:
                 for s, b in M3u8.get_streams_from_m3u8(url):
                     item.complete = True
-                    part.append_media_stream(s, b)
+                    item.add_stream(s, b)
 
         return item
 

--- a/channels/channel.nos/nos2010/chn_nos2010.py
+++ b/channels/channel.nos/nos2010/chn_nos2010.py
@@ -1161,7 +1161,7 @@ class Channel(chn_class.Channel):
         self.update_video_item method is called if the item is focussed or selected
         for playback.
 
-        :param list[str]|dict result_set: The result_set of the self.episodeItemRegex
+        :param dict result_set: The result_set of the self.episodeItemRegex
 
         :return: A new MediaItem of type 'video' or 'audio' (despite the method's name).
         :rtype: MediaItem|None
@@ -1179,7 +1179,6 @@ class Channel(chn_class.Channel):
 
         # noinspection PyTypeChecker
         streams = result_set.get("audiostreams", [])
-        part = item.create_new_empty_media_part()
 
         # first check for the video streams
         # noinspection PyTypeChecker
@@ -1201,7 +1200,7 @@ class Channel(chn_class.Channel):
                 continue
             bitrate = stream.get("bitrate", 0)
             url = stream["url"]
-            part.append_media_stream(url, bitrate)
+            item.add_stream(url, bitrate)
             item.complete = True
             # if not stream["protocol"] == "prid":
             #     continue
@@ -1287,9 +1286,6 @@ class Channel(chn_class.Channel):
 
         Logger.debug('Starting update_video_item: %s', item.name)
 
-        item.MediaItemParts = []
-        part = item.create_new_empty_media_part()
-
         # we need to determine radio or live tv
         Logger.debug("Fetching live stream data from item url: %s", item.url)
         html_data = UriHandler.open(item.url)
@@ -1297,7 +1293,7 @@ class Channel(chn_class.Channel):
         mp3_urls = Regexer.do_regex("""data-streams='{"url":"([^"]+)","codec":"[^"]+"}'""", html_data)
         if len(mp3_urls) > 0:
             Logger.debug("Found MP3 URL")
-            part.append_media_stream(mp3_urls[0], 192)
+            item.add_stream(mp3_urls[0], 192)
         else:
             Logger.debug("Finding the actual metadata url from %s", item.url)
             # NPO3 normal stream had wrong subs
@@ -1354,23 +1350,20 @@ class Channel(chn_class.Channel):
 
         Logger.trace("Using Generic update_video_item method")
 
-        item.MediaItemParts = []
-        part = item.create_new_empty_media_part()
-
         # get the subtitle
         if fetch_subtitles:
             sub_title_url = "https://assetscdn.npostart.nl/subtitles/original/nl/%s.vtt" % (episode_id,)
             sub_title_path = subtitlehelper.SubtitleHelper.download_subtitle(
                 sub_title_url, episode_id + ".nl.srt", format='srt')
             if sub_title_path:
-                part.Subtitle = sub_title_path
+                item.subtitle = sub_title_path
 
         if AddonSettings.use_adaptive_stream_add_on(
                 with_encryption=True, ignore_add_on_config=True):
-            error = NpoStream.add_mpd_stream_from_npo(None, episode_id, part, live=item.isLive)
+            error = NpoStream.add_mpd_stream_from_npo(None, episode_id, item, live=item.isLive)
             if bool(error) and self.__has_premium():
                 self.__log_on(force_log_off=True)
-                error = NpoStream.add_mpd_stream_from_npo(None, episode_id, part, live=item.isLive)
+                error = NpoStream.add_mpd_stream_from_npo(None, episode_id, item, live=item.isLive)
 
             if bool(error):
                 XbmcWrapper.show_dialog(

--- a/channels/channel.nos/nos2010/chn_nos2010.py
+++ b/channels/channel.nos/nos2010/chn_nos2010.py
@@ -1217,10 +1217,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -1246,10 +1246,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -1271,10 +1271,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -1333,10 +1333,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item:          the original MediaItem that needs updating.

--- a/channels/channel.nos/nosnl/chn_nosnl.py
+++ b/channels/channel.nos/nosnl/chn_nosnl.py
@@ -188,10 +188,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.nos/nosnl/chn_nosnl.py
+++ b/channels/channel.nos/nosnl/chn_nosnl.py
@@ -210,7 +210,6 @@ class Channel(chn_class.Channel):
             return item
 
         qualities = {"720p": 1600, "480p": 1200, "360p": 500, "other": 0}  # , "http-hls": 1500, "3gp-mob01": 300, "flv-web01": 500}
-        part = item.create_new_empty_media_part()
         urls = []
         for stream in streams:
             url = list(stream["url"].values())[-1]
@@ -222,7 +221,7 @@ class Channel(chn_class.Channel):
 
             # actually process the url
             if ".m3u8" not in url:
-                part.append_media_stream(
+                item.add_stream(
                     url=url,
                     bitrate=qualities.get(stream.get("name", "other"), 0)
                 )
@@ -233,5 +232,5 @@ class Channel(chn_class.Channel):
             #     M3u8.SetInputStreamAddonInput(stream)
             #     item.complete = True
             else:
-                M3u8.update_part_with_m3u8_streams(part, url, channel=self)
+                M3u8.update_part_with_m3u8_streams(item, url, channel=self)
         return item

--- a/channels/channel.nos/schooltv/chn_schooltv.py
+++ b/channels/channel.nos/schooltv/chn_schooltv.py
@@ -287,19 +287,18 @@ class Channel(chn_class.Channel):
         data = UriHandler.open(item.url, additional_headers=item.HttpHeaders)
         json = JsonHelper(data)
 
-        part = item.create_new_empty_media_part()
-        part.Subtitle = NpoStream.get_subtitle(json.get_value("mid"))
+        item.subtitle = NpoStream.get_subtitle(json.get_value("mid"))
 
         for stream in json.get_value("videoStreams"):
             if not stream["url"].startswith("odi"):
-                part.append_media_stream(stream["url"], stream["bitrate"] / 1000)
+                item.add_stream(stream["url"], stream["bitrate"] / 1000)
                 item.complete = True
 
-        if item.has_media_item_parts():
+        if item.has_streams():
             return item
 
         for s, b in NpoStream.get_streams_from_npo(None, json.get_value("mid")):
             item.complete = True
-            part.append_media_stream(s, b)
+            item.add_stream(s, b)
 
         return item

--- a/channels/channel.nos/schooltv/chn_schooltv.py
+++ b/channels/channel.nos/schooltv/chn_schooltv.py
@@ -269,10 +269,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.regionalnl/at5/chn_at5.py
+++ b/channels/channel.regionalnl/at5/chn_at5.py
@@ -263,8 +263,7 @@ class Channel(chn_class.Channel):
 
         Logger.debug('Starting update_video_item for %s (%s)', item.name, self.channelName)
 
-        part = item.create_new_empty_media_part()
-        item.complete = M3u8.update_part_with_m3u8_streams(part, item.url, channel=self)
+        item.complete = M3u8.update_part_with_m3u8_streams(item, item.url, channel=self)
         return item
 
     def update_live_stream(self, item):
@@ -293,8 +292,7 @@ class Channel(chn_class.Channel):
         url = "https://rrr.sz.xlcdn.com/?account=atvijf" \
               "&file=live&type=live&service=wowza&protocol=https&output=playlist.m3u8"
 
-        part = item.create_new_empty_media_part()
         item.complete = \
-            M3u8.update_part_with_m3u8_streams(part, url, channel=self)
+            M3u8.update_part_with_m3u8_streams(item, url, channel=self)
 
         return item

--- a/channels/channel.regionalnl/at5/chn_at5.py
+++ b/channels/channel.regionalnl/at5/chn_at5.py
@@ -248,10 +248,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -275,10 +275,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.regionalnl/flevo/chn_flevo.py
+++ b/channels/channel.regionalnl/flevo/chn_flevo.py
@@ -150,10 +150,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -186,10 +186,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.regionalnl/flevo/chn_flevo.py
+++ b/channels/channel.regionalnl/flevo/chn_flevo.py
@@ -166,13 +166,12 @@ class Channel(chn_class.Channel):
         data = UriHandler.open(item.url)
         stream = Regexer.do_regex(r'data-file="([^"]+)+', data)[0]
 
-        part = item.create_new_empty_media_part()
         if ".mp3" in stream:
             item.complete = True
-            part.append_media_stream(stream, 0)
+            item.add_stream(stream, 0)
         elif stream.endswith(".mp4"):
             item.complete = True
-            part.append_media_stream(stream, 2500)
+            item.add_stream(stream, 2500)
         elif ".m3u8" in stream:
             item.url = stream
             return self.update_live_urls(item)
@@ -202,15 +201,14 @@ class Channel(chn_class.Channel):
 
         Logger.debug('Starting update_video_item for %s (%s)', item.name, self.channelName)
 
-        part = item.create_new_empty_media_part()
         if AddonSettings.use_adaptive_stream_add_on():
-            stream = part.append_media_stream(item.url, 0)
+            stream = item.add_stream(item.url, 0)
             M3u8.set_input_stream_addon_input(stream)
             item.complete = True
         else:
 
             for s, b in M3u8.get_streams_from_m3u8(item.url):
                 item.complete = True
-                part.append_media_stream(s, b)
+                item.add_stream(s, b)
             item.complete = True
         return item

--- a/channels/channel.regionalnl/gelderland/chn_gelderland.py
+++ b/channels/channel.regionalnl/gelderland/chn_gelderland.py
@@ -103,7 +103,7 @@ class Channel(chn_class.Channel):
         
         item = MediaItem(name, url, media_type=mediatype.EPISODE)
         item.thumb = thumb_url
-        item.append_single_stream(video_url)
+        item.add_stream(video_url)
         
         # set date
         month = datehelper.DateHelper.get_month_from_name(result_set[3], "nl", False)

--- a/channels/channel.regionalnl/l1/chn_l1.py
+++ b/channels/channel.regionalnl/l1/chn_l1.py
@@ -157,10 +157,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -191,10 +191,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -223,7 +223,7 @@ class Channel(chn_class.Channel):
 
         base_url = json.get_value("publicationData", "defaultMediaAssetPath")
         streams = json.get_value("clipData", "assets")
-        item.MediaItemParts = []
+        item.streams = []
         for stream in streams:
             url = stream.get("src", None)
             if "://" not in url:

--- a/channels/channel.regionalnl/l1/chn_l1.py
+++ b/channels/channel.regionalnl/l1/chn_l1.py
@@ -170,15 +170,14 @@ class Channel(chn_class.Channel):
 
         """
 
-        part = item.create_new_empty_media_part()
         if item.url == "#livetv":
             url = "https://d34pj260kw1xmk.cloudfront.net/live/l1/tv/index.m3u8"
-            M3u8.update_part_with_m3u8_streams(part, url, encrypted=True)
+            M3u8.update_part_with_m3u8_streams(item, url, encrypted=True)
         else:
             # the audio won't play with the InputStream Adaptive add-on.
             url = "https://d34pj260kw1xmk.cloudfront.net/live/l1/radio/index.m3u8"
             for s, b in M3u8.get_streams_from_m3u8(url):
-                part.append_media_stream(s, b)
+                item.add_stream(s, b)
 
         item.complete = True
         return item
@@ -225,14 +224,13 @@ class Channel(chn_class.Channel):
         base_url = json.get_value("publicationData", "defaultMediaAssetPath")
         streams = json.get_value("clipData", "assets")
         item.MediaItemParts = []
-        part = item.create_new_empty_media_part()
         for stream in streams:
             url = stream.get("src", None)
             if "://" not in url:
                 url = "{}{}".format(base_url, url)
             bitrate = stream.get("bandwidth", None)
             if url:
-                part.append_media_stream(url, bitrate)
+                item.add_stream(url, bitrate)
 
         if not item.thumb and json.get_value("thumbnails"):
             url = json.get_value("thumbnails")[0].get("src", None)

--- a/channels/channel.regionalnl/lokaal/chn_lokaal.py
+++ b/channels/channel.regionalnl/lokaal/chn_lokaal.py
@@ -203,7 +203,7 @@ class Channel(chn_class.Channel):
             live_item.isLive = True
             if self.channelCode == "rtvdrenthe":
                 # RTV Drenthe actually has a buggy M3u8 without master index.
-                live_item.append_single_stream(live_item.url, 0)
+                live_item.add_stream(live_item.url, 0)
                 live_item.complete = True
 
             items.append(live_item)
@@ -232,7 +232,6 @@ class Channel(chn_class.Channel):
             live_item.type = 'video'
             live_item.complete = True
             live_item.isLive = True
-            part = live_item.create_new_empty_media_part()
             for stream in streams:
                 Logger.trace(stream)
                 bitrate = None
@@ -275,7 +274,7 @@ class Channel(chn_class.Channel):
                     url = "%s?protection=url" % (url, )
 
                 if bitrate:
-                    part.append_media_stream(url, bitrate)
+                    live_item.add_stream(url, bitrate)
 
                     if url == live_stream_value and ".m3u8" in url:
                         # if it was equal to the previous one, assume we have a m3u8. Reset the others.
@@ -362,7 +361,7 @@ class Channel(chn_class.Channel):
         item = MediaItem(title, url, media_type=mediatype.EPISODE)
 
         if media_link:
-            item.append_single_stream(media_link, self.channelBitrate)
+            item.add_stream(media_link, self.channelBitrate)
 
         # get the thumbs from multiple locations
         thumb_urls = result_set.get("images", None)
@@ -421,7 +420,7 @@ class Channel(chn_class.Channel):
         item.isLive = True
 
         if result_set["mediaType"].lower() == "audio":
-            item.append_single_stream(item.url)
+            item.add_stream(item.url)
             item.media_type = mediatype.AUDIO
             item.complete = True
             return item
@@ -453,16 +452,14 @@ class Channel(chn_class.Channel):
         Logger.debug("Updating a (Live) video item")
         content, url = UriHandler.header(item.url)
 
-        part = item.create_new_empty_media_part()
         if AddonSettings.use_adaptive_stream_add_on():
-            part = item.create_new_empty_media_part()
-            stream = part.append_media_stream(url, 0)
+            stream = item.add_stream(url, 0)
             M3u8.set_input_stream_addon_input(stream, item.HttpHeaders)
             item.complete = True
         else:
             for s, b in M3u8.get_streams_from_m3u8(url, append_query_string=True):
                 item.complete = True
-                part.append_media_stream(s, b)
+                item.add_stream(s, b)
             item.complete = True
 
         return item

--- a/channels/channel.regionalnl/lokaal/chn_lokaal.py
+++ b/channels/channel.regionalnl/lokaal/chn_lokaal.py
@@ -279,14 +279,14 @@ class Channel(chn_class.Channel):
                     if url == live_stream_value and ".m3u8" in url:
                         # if it was equal to the previous one, assume we have a m3u8. Reset the others.
                         Logger.info("Found same M3u8 stream for all streams for this Live channel, using that one: %s", url)
-                        live_item.MediaItemParts = []
+                        live_item.streams = []
                         live_item.url = url
                         live_item.complete = False
                         break
                     elif "playlist.m3u8" in url:
                         # if we have a playlist, use that one. Reset the others.
                         Logger.info("Found M3u8 playlist for this Live channel, using that one: %s", url)
-                        live_item.MediaItemParts = []
+                        live_item.streams = []
                         live_item.url = url
                         live_item.complete = False
                         break
@@ -436,10 +436,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.regionalnl/openregio/chn_openregio.py
+++ b/channels/channel.regionalnl/openregio/chn_openregio.py
@@ -268,10 +268,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -300,10 +300,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.regionalnl/openregio/chn_openregio.py
+++ b/channels/channel.regionalnl/openregio/chn_openregio.py
@@ -316,16 +316,15 @@ class Channel(chn_class.Channel):
         Logger.debug("Updating a (Live) video item")
 
         if item.is_audio:
-            item.append_single_stream(item.url, 0)
+            item.add_stream(item.url, 0)
             item.complete = True
 
         elif ".m3u8" in item.url:
-            part = item.create_new_empty_media_part()
             item.complete = M3u8.update_part_with_m3u8_streams(
-                part, item.url, channel=self, encrypted=False)
+                item, item.url, channel=self, encrypted=False)
 
         elif item.url.endswith(".mp4"):
-            item.append_single_stream(item.url, self.channelBitrate)
+            item.add_stream(item.url, self.channelBitrate)
             item.complete = True
 
         return item

--- a/channels/channel.regionalnl/rpoapp/chn_rpoapp.py
+++ b/channels/channel.regionalnl/rpoapp/chn_rpoapp.py
@@ -155,7 +155,7 @@ class Channel(chn_class.Channel):
         item.isLive = True
 
         if item.url.endswith(".mp3"):
-            item.append_single_stream(item.url)
+            item.add_stream(item.url)
             item.complete = True
             return item
 
@@ -280,15 +280,14 @@ class Channel(chn_class.Channel):
 
         """
 
-        part = item.create_new_empty_media_part()
         if AddonSettings.use_adaptive_stream_add_on():
-            stream = part.append_media_stream(item.url, 0)
+            stream = item.add_stream(item.url, 0)
             M3u8.set_input_stream_addon_input(stream)
             item.complete = True
         else:
             for s, b in M3u8.get_streams_from_m3u8(item.url):
                 item.complete = True
-                part.append_media_stream(s, b)
+                item.add_stream(s, b)
         return item
 
     def update_video_item_json_player(self, item):
@@ -316,10 +315,9 @@ class Channel(chn_class.Channel):
         data = UriHandler.open(item.url)
         streams = Regexer.do_regex(r'label:\s*"([^"]+)",\W*file:\s*"([^"]+)"', data)
 
-        part = item.create_new_empty_media_part()
         bitrates = {"720p SD": 1200}
         for stream in streams:
-            part.append_media_stream(stream[1], bitrates.get(stream[0], 0))
+            item.add_stream(stream[1], bitrates.get(stream[0], 0))
             item.complete = True
 
         return item
@@ -361,9 +359,8 @@ class Channel(chn_class.Channel):
         json_data = JsonHelper(json_data[0])
         clip_data = json_data.get_value("clipData", "assets")
         server = json_data.get_value("publicationData", "defaultMediaAssetPath")
-        part = item.create_new_empty_media_part()
         for clip in clip_data:
-            part.append_media_stream("{}{}".format(server, clip["src"]), int(clip["bandwidth"]))
+            item.add_stream("{}{}".format(server, clip["src"]), int(clip["bandwidth"]))
             item.complete = True
 
         return item

--- a/channels/channel.regionalnl/rpoapp/chn_rpoapp.py
+++ b/channels/channel.regionalnl/rpoapp/chn_rpoapp.py
@@ -267,10 +267,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -299,10 +299,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -331,10 +331,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.rtlnl/rtl/chn_rtl.py
+++ b/channels/channel.rtlnl/rtl/chn_rtl.py
@@ -598,10 +598,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.rtlnl/rtl/chn_rtl.py
+++ b/channels/channel.rtlnl/rtl/chn_rtl.py
@@ -153,11 +153,11 @@ class Channel(chn_class.Channel):
         )
         stream_item.complete = True
         stream_item.dontGroup = True
-        stream_item.append_single_stream("http://mss6.rtl7.nl/rtlzbroad", 1200)
-        stream_item.append_single_stream("http://mss26.rtl7.nl/rtlzbroad", 1200)
-        stream_item.append_single_stream("http://mss4.rtl7.nl/rtlzbroad", 1200)
-        stream_item.append_single_stream("http://mss5.rtl7.nl/rtlzbroad", 1200)
-        stream_item.append_single_stream("http://mss3.rtl7.nl/rtlzbroad", 1200)
+        stream_item.add_stream("http://mss6.rtl7.nl/rtlzbroad", 1200)
+        stream_item.add_stream("http://mss26.rtl7.nl/rtlzbroad", 1200)
+        stream_item.add_stream("http://mss4.rtl7.nl/rtlzbroad", 1200)
+        stream_item.add_stream("http://mss5.rtl7.nl/rtlzbroad", 1200)
+        stream_item.add_stream("http://mss3.rtl7.nl/rtlzbroad", 1200)
 
         rtlz_live.items.append(stream_item)
         items.append(rtlz_live)
@@ -628,8 +628,7 @@ class Channel(chn_class.Channel):
             "content-type": "application/octet-stream"
         }
 
-        part = item.create_new_empty_media_part()
-        stream = part.append_media_stream(video_manifest, 0)
+        stream = item.add_stream(video_manifest, 0)
 
         from resources.lib.streams.mpd import Mpd
         license_key = Mpd.get_license_key(license_url, key_headers=key_headers, key_type="A")

--- a/channels/channel.sbsnl/kijknl/chn_kijknl.py
+++ b/channels/channel.sbsnl/kijknl/chn_kijknl.py
@@ -194,10 +194,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.sbsnl/kijknl/chn_kijknl.py
+++ b/channels/channel.sbsnl/kijknl/chn_kijknl.py
@@ -234,7 +234,6 @@ class Channel(chn_class.Channel):
             return self.__update_video_from_mpd(item, mpd_info, use_adaptive_with_encryption)
 
         # Try the plain M3u8 streams
-        part = item.create_new_empty_media_part()
         m3u8_url = json.get_value("playlist")
         use_adaptive = AddonSettings.use_adaptive_stream_add_on(channel=self)
 
@@ -250,12 +249,12 @@ class Channel(chn_class.Channel):
                 if use_adaptive:
                     # we have at least 1 none encrypted streams
                     Logger.info("Using HLS InputStreamAddon")
-                    strm = part.append_media_stream(m3u8_url, 0)
+                    strm = item.add_stream(m3u8_url, 0)
                     M3u8.set_input_stream_addon_input(strm)
                     item.complete = True
                     return item
 
-                part.append_media_stream(s, b)
+                item.add_stream(s, b)
                 item.complete = True
             return item
 
@@ -277,14 +276,14 @@ class Channel(chn_class.Channel):
             if use_adaptive:
                 # we have at least 1 none encrypted streams
                 Logger.info("Using HLS InputStreamAddon")
-                strm = part.append_media_stream(m3u8_url, 0)
+                strm = item.add_stream(m3u8_url, 0)
                 M3u8.set_input_stream_addon_input(strm)
                 item.complete = True
                 return item
 
             for s, b in M3u8.get_streams_from_m3u8(m3u8_url, append_query_string=True):
                 item.complete = True
-                part.append_media_stream(s, b)
+                item.add_stream(s, b)
 
             return item
 
@@ -317,7 +316,6 @@ class Channel(chn_class.Channel):
         adaptive_available_encrypted = AddonSettings.use_adaptive_stream_add_on(with_encryption=True, channel=self)
 
         for play_list_entry in json.get_value("playlist"):
-            part = item.create_new_empty_media_part()
             for source in play_list_entry["sources"]:
                 stream_type = source["type"]
                 stream_url = source["file"]
@@ -327,11 +325,11 @@ class Channel(chn_class.Channel):
                     has_drm_only = False
                     if stream_type == "m3u8":
                         Logger.debug("Found non-encrypted M3u8 stream: %s", stream_url)
-                        M3u8.update_part_with_m3u8_streams(part, stream_url, channel=self)
+                        M3u8.update_part_with_m3u8_streams(item, stream_url, channel=self)
                         item.complete = True
                     elif stream_type == "dash" and adaptive_available:
                         Logger.debug("Found non-encrypted Dash stream: %s", stream_url)
-                        stream = part.append_media_stream(stream_url, 1)
+                        stream = item.add_stream(stream_url, 1)
                         Mpd.set_input_stream_addon_input(stream)
                         item.complete = True
                     else:
@@ -359,7 +357,7 @@ class Channel(chn_class.Channel):
                     encryption_key = Mpd.get_license_key(
                         license_url, key_type=None, key_value=encryption_json, key_headers=headers)
 
-                    stream = part.append_media_stream(stream_url, 0)
+                    stream = item.add_stream(stream_url, 0)
                     Mpd.set_input_stream_addon_input(
                         stream, license_key=encryption_key)
                     item.complete = True
@@ -367,7 +365,7 @@ class Channel(chn_class.Channel):
             subs = [s['file'] for s in play_list_entry.get("tracks", []) if s.get('kind') == "captions"]
             if subs:
                 subtitle = SubtitleHelper.download_subtitle(subs[0], format="webvtt")
-                part.Subtitle = subtitle
+                item.subtitle = subtitle
 
         if has_drm_only and not adaptive_available_encrypted:
             XbmcWrapper.show_dialog(
@@ -390,7 +388,6 @@ class Channel(chn_class.Channel):
 
         Logger.debug("Updating streams using BrightCove data.")
 
-        part = item.create_new_empty_media_part()
         mpd_manifest_url = "https:{0}".format(mpd_info["mediaLocator"])
         mpd_data = UriHandler.open(mpd_manifest_url)
         subtitles = Regexer.do_regex(r'<BaseURL>([^<]+\.vtt)</BaseURL>', mpd_data)
@@ -398,7 +395,7 @@ class Channel(chn_class.Channel):
         if subtitles:
             Logger.debug("Found subtitle: %s", subtitles[0])
             subtitle = SubtitleHelper.download_subtitle(subtitles[0], format="webvtt")
-            part.Subtitle = subtitle
+            item.subtitle = subtitle
 
         if use_adaptive_with_encryption:
             # We can use the adaptive add-on with encryption
@@ -408,7 +405,7 @@ class Channel(chn_class.Channel):
             key_headers = {"Authorization": token}
             license_key = Mpd.get_license_key(license_url, key_headers=key_headers)
 
-            stream = part.append_media_stream(mpd_manifest_url, 0)
+            stream = item.add_stream(mpd_manifest_url, 0)
             Mpd.set_input_stream_addon_input(stream, license_key=license_key)
             item.complete = True
         else:
@@ -431,7 +428,6 @@ class Channel(chn_class.Channel):
 
         """
 
-        part = item.create_new_empty_media_part()
         # Then try the new BrightCove JSON
         bright_cove_regex = '<video[^>]+data-video-id="(?<videoId>[^"]+)[^>]+data-account="(?<videoAccount>[^"]+)'
         bright_cove_data = Regexer.do_regex(Regexer.from_expresso(bright_cove_regex), data)
@@ -462,14 +458,14 @@ class Channel(chn_class.Channel):
         # "range" http header
         if use_adaptive_with_encryption:
             Logger.info("Using InputStreamAddon for playback of HLS stream")
-            strm = part.append_media_stream(stream_url, 0)
+            strm = item.add_stream(stream_url, 0)
             M3u8.set_input_stream_addon_input(strm)
             item.complete = True
             return item
 
         for s, b in M3u8.get_streams_from_m3u8(stream_url):
             item.complete = True
-            part.append_media_stream(s, b)
+            item.add_stream(s, b)
         return item
 
     #region GraphQL data
@@ -792,7 +788,6 @@ class Channel(chn_class.Channel):
         """
 
         sources = item.metaData["sources"]
-        part = item.create_new_empty_media_part()
         hls_over_dash = self._get_setting("hls_over_dash") == "true"
 
         for src in sources:
@@ -804,12 +799,12 @@ class Channel(chn_class.Channel):
 
             if stream_type == "dash" and not drm:
                 bitrate = 0 if hls_over_dash else 2
-                stream = part.append_media_stream(url, bitrate)
+                stream = item.add_stream(url, bitrate)
                 item.complete = Mpd.set_input_stream_addon_input(stream)
 
             elif stream_type == "dash" and drm and "widevine" in drm:
                 bitrate = 0 if hls_over_dash else 1
-                stream = part.append_media_stream(url, bitrate)
+                stream = item.add_stream(url, bitrate)
 
                 # fetch the authentication token:
                 # url = self.__get_api_persisted_url("drmToken", "634c83ae7588a877e2bb67d078dda618cfcfc70ac073aef5e134e622686c0bb6", variables={})
@@ -834,7 +829,7 @@ class Channel(chn_class.Channel):
             elif stream_type == "m3u8" and not drm:
                 bitrate = 2 if hls_over_dash else 0
                 item.complete = M3u8.update_part_with_m3u8_streams(
-                    part, url, channel=self, bitrate=bitrate)
+                    item, url, channel=self, bitrate=bitrate)
 
             else:
                 Logger.debug("Found incompatible stream: %s", src)
@@ -842,7 +837,7 @@ class Channel(chn_class.Channel):
         subtitle = None
         for sub in item.metaData.get("subtitles", []):
             subtitle = sub["file"]
-        part.Subtitle = subtitle
+        item.subtitle = subtitle
 
         # If we are here, we can playback.
         item.isDrmProtected = False

--- a/channels/channel.se/oppetarkiv/chn_oppetarkiv.py
+++ b/channels/channel.se/oppetarkiv/chn_oppetarkiv.py
@@ -273,7 +273,6 @@ class Channel(chn_class.Channel):
         json = JsonHelper(data, Logger.instance())
         video_data = json.get_value("video")
         if video_data:
-            part = item.create_new_empty_media_part()
 
             # Get the videos
             video_infos = video_data.get("videoReferences")
@@ -294,10 +293,10 @@ class Channel(chn_class.Channel):
                     continue
 
                 if "hls" in video_type or "ios" in video_type:
-                    M3u8.update_part_with_m3u8_streams(part, video_url)
+                    M3u8.update_part_with_m3u8_streams(item, video_url)
 
                 elif "dash" in video_type:
-                    stream = part.append_media_stream(video_url, supported_formats[video_type])
+                    stream = item.add_stream(video_url, supported_formats[video_type])
                     Mpd.set_input_stream_addon_input(stream)
 
                 else:
@@ -309,7 +308,7 @@ class Channel(chn_class.Channel):
                 # elif "master.m3u8" in stream_info:
                 #     for s, b in M3u8.get_streams_from_m3u8(stream_info, headers=part.HttpHeaders):
                 #         item.complete = True
-                #         part.append_media_stream(s, b)
+                #         item.add_stream(s, b)
 
             # subtitles
             subtitles = video_data.get("subtitleReferences")
@@ -329,7 +328,7 @@ class Channel(chn_class.Channel):
                 with open(local_complete_path, 'w') as f:
                     f.write(sub_data)
 
-                part.Subtitle = local_complete_path
+                item.Subtitle = local_complete_path
 
             item.complete = True
 

--- a/channels/channel.se/oppetarkiv/chn_oppetarkiv.py
+++ b/channels/channel.se/oppetarkiv/chn_oppetarkiv.py
@@ -254,10 +254,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.se/sbs/chn_sbs.py
+++ b/channels/channel.se/sbs/chn_sbs.py
@@ -521,10 +521,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -689,10 +689,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.se/sbs/chn_sbs.py
+++ b/channels/channel.se/sbs/chn_sbs.py
@@ -535,8 +535,7 @@ class Channel(chn_class.Channel):
         """
 
         video_id = item.url.rsplit("/", 1)[-1]
-        part = item.create_new_empty_media_part()
-        item.complete = self.__get_video_streams(video_id, part)
+        item.complete = self.__get_video_streams(video_id, item)
         return item
 
     def log_on(self, username=None, password=None):
@@ -720,18 +719,15 @@ class Channel(chn_class.Channel):
         if errors:
             return item
 
-        part = item.create_new_empty_media_part()
-
         m3u8url = video_info["streaming"]["hls"]["url"]
-
         m3u8data = UriHandler.open(m3u8url)
         if AddonSettings.use_adaptive_stream_add_on():
-            stream = part.append_media_stream(m3u8url, 0)
+            stream = item.add_stream(m3u8url, 0)
             item.complete = True
             M3u8.set_input_stream_addon_input(stream)
         else:
             # user agent for all sub m3u8 and ts requests needs to be the same
-            part.HttpHeaders["user-agent"] = "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-GB; rv:1.9.2.13) Gecko/20101203 Firefox/3.6.13 (.NET CLR 3.5.30729)"
+            stream_headers = {"user-agent": "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-GB; rv:1.9.2.13) Gecko/20101203 Firefox/3.6.13 (.NET CLR 3.5.30729)"}
             for s, b, a in M3u8.get_streams_from_m3u8(m3u8url, append_query_string=False,
                                                       map_audio=True, play_list_data=m3u8data):
                 item.complete = True
@@ -739,7 +735,8 @@ class Channel(chn_class.Channel):
                     audio_part = a.split("-prog_index.m3u8", 1)[0]
                     audio_id = audio_part.rsplit("/", 1)[-1]
                     s = s.replace("-prog_index.m3u8", "-{0}-prog_index.m3u8".format(audio_id))
-                part.append_media_stream(s, b)
+                stream = item.add_stream(s, b)
+                stream.HttpHeaders.update(stream_headers)
 
         if self.language == "se":
             vtt_url = M3u8.get_subtitle(m3u8url, m3u8data, language="sv")
@@ -750,7 +747,7 @@ class Channel(chn_class.Channel):
 
         # https://dplaynordics-vod-80.akamaized.net/dplaydni/259/0/hls/243241001/1112635959-prog_index.m3u8?version_hash=bb753129&hdnts=st=1518218118~exp=1518304518~acl=/*~hmac=bdeefe0ec880f8614e14af4d4a5ca4d3260bf2eaa8559e1eb8ba788645f2087a
         vtt_url = vtt_url.replace("-prog_index.m3u8", "-0.vtt")
-        part.Subtitle = SubtitleHelper.download_subtitle(vtt_url, format='srt')
+        item.subtitle = SubtitleHelper.download_subtitle(vtt_url, format='srt')
 
         # if the user has premium, don't show any warnings
         if self.__has_premium:
@@ -843,12 +840,14 @@ class Channel(chn_class.Channel):
         self.showLookup.update(shows)
         self.imageLookup.update(images)
 
-    def __get_video_streams(self, video_id, part):
+    def __get_video_streams(self, video_id, item):
         """ Fetches the video stream for a given videoId
 
-        @param video_id: (integer) the videoId
-        @param part:    (MediaPart) the mediapart to add the streams to
-        @return:        (bool) indicating a successfull retrieval
+        :param int video_id:        The videoId
+        :param MediaItem item:      The mediapart to add the streams to
+
+        :returns: indicating a successfull retrieval
+        :rtype: bool
 
         """
 
@@ -886,7 +885,7 @@ class Channel(chn_class.Channel):
                 else:
                     s = "%s?%s" % (s, qs)
 
-            part.append_media_stream(s, b)
+            item.add_stream(s, b)
 
         return streams_found
 

--- a/channels/channel.se/svt/chn_svt.py
+++ b/channels/channel.se/svt/chn_svt.py
@@ -1153,7 +1153,6 @@ class Channel(chn_class.Channel):
         """
 
         item.MediaItemParts = []
-        part = item.create_new_empty_media_part()
         use_input_stream = AddonSettings.use_adaptive_stream_add_on(channel=self)
         in_sweden = self.__validate_location()
         Logger.debug("Streaming location within GEO area: %s", in_sweden)
@@ -1178,12 +1177,12 @@ class Channel(chn_class.Channel):
             Logger.debug("Found video item for format: %s", video_format)
 
             url = video['url']
-            if any(filter(lambda s: s.Url == url, part.MediaStreams)):
+            if any(filter(lambda s: s.Url == url, item.streams)):
                 Logger.debug("Skippping duplicate Stream url: %s", url)
                 continue
 
             if "dash" in video_format and use_input_stream:
-                stream = part.append_media_stream(video['url'], supported_formats[video_format])
+                stream = item.add_stream(video['url'], supported_formats[video_format])
                 Mpd.set_input_stream_addon_input(stream)
 
             elif "m3u8" in url:
@@ -1196,21 +1195,20 @@ class Channel(chn_class.Channel):
                     continue
 
                 M3u8.update_part_with_m3u8_streams(
-                    part,
+                    item,
                     url,
                     encrypted=False,
-                    headers=part.HttpHeaders,
                     channel=self,
                     bitrate=supported_formats[video_format]
                 )
 
             elif video["url"].startswith("rtmp"):
                 # just replace some data in the URL
-                part.append_media_stream(
+                item.add_stream(
                     self.get_verifiable_video_url(video["url"]).replace("_definst_", "?slist="),
                     video[1])
             else:
-                part.append_media_stream(url, 0)
+                item.add_stream(url, 0)
 
         if subtitles:
             Logger.info("Found subtitles to play")
@@ -1225,7 +1223,7 @@ class Channel(chn_class.Channel):
                     # look for more
                     continue
 
-                part.Subtitle = subtitlehelper.SubtitleHelper.download_subtitle(
+                item.subtitle = subtitlehelper.SubtitleHelper.download_subtitle(
                     sub_url, format="srt", replace={"&amp;": "&"})
                 # stop when finding one
                 break

--- a/channels/channel.se/svt/chn_svt.py
+++ b/channels/channel.se/svt/chn_svt.py
@@ -1015,10 +1015,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -1047,10 +1047,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -1152,7 +1152,7 @@ class Channel(chn_class.Channel):
 
         """
 
-        item.MediaItemParts = []
+        item.streams = []
         use_input_stream = AddonSettings.use_adaptive_stream_add_on(channel=self)
         in_sweden = self.__validate_location()
         Logger.debug("Streaming location within GEO area: %s", in_sweden)

--- a/channels/channel.se/tv4se/chn_tv4se.py
+++ b/channels/channel.se/tv4se/chn_tv4se.py
@@ -650,10 +650,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -724,10 +724,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -739,7 +739,7 @@ class Channel(chn_class.Channel):
 
         Logger.debug('Starting update_live_item for %s (%s)', item.name, self.channelName)
 
-        item.MediaItemParts = []
+        item.streams = []
         for s, b in M3u8.get_streams_from_m3u8(item.url):
             item.add_stream(s, b)
 

--- a/channels/channel.se/urplay/chn_urplay.py
+++ b/channels/channel.se/urplay/chn_urplay.py
@@ -572,7 +572,6 @@ class Channel(chn_class.Channel):
         Logger.trace("Found RTMP Proxy: %s", proxy)
 
         stream_infos = json.get_value("program", "streamingInfo")
-        part = item.create_new_empty_media_part()
         for stream_type, stream_info in stream_infos.items():
             Logger.trace(stream_info)
             default_stream = stream_info.get("default", False)
@@ -583,7 +582,7 @@ class Channel(chn_class.Channel):
                     continue
                 stream_url = stream["location"]
                 if quality == "tt":
-                    part.Subtitle = SubtitleHelper.download_subtitle(
+                    item.subtitle = SubtitleHelper.download_subtitle(
                         stream_url, format="ttml")
                     continue
 
@@ -591,7 +590,7 @@ class Channel(chn_class.Channel):
                 if stream_type == "raw":
                     bitrate += 1
                 url = "https://%s/%smaster.m3u8" % (proxy, stream_url)
-                part.append_media_stream(url, bitrate)
+                item.add_stream(url, bitrate)
 
         item.complete = True
         return item

--- a/channels/channel.se/urplay/chn_urplay.py
+++ b/channels/channel.se/urplay/chn_urplay.py
@@ -522,10 +522,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -562,7 +562,7 @@ class Channel(chn_class.Channel):
         json = JsonHelper(json_data, logger=Logger.instance())
         Logger.trace(json.json)
 
-        item.MediaItemParts = []
+        item.streams = []
 
         # generic server information
         proxy_data = UriHandler.open("https://streaming-loadbalancer.ur.se/loadbalancer.json",

--- a/channels/channel.streams/24classic/chn_24classic.py
+++ b/channels/channel.streams/24classic/chn_24classic.py
@@ -155,10 +155,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.streams/24classic/chn_24classic.py
+++ b/channels/channel.streams/24classic/chn_24classic.py
@@ -177,6 +177,6 @@ class Channel(chn_class.Channel):
         url = json_data.get_value("url", fallback=None)
 
         if url:
-            item.append_single_stream(url)
+            item.add_stream(url)
             item.Complete = True
         return item

--- a/channels/channel.streams/radio538/chn_radio538.py
+++ b/channels/channel.streams/radio538/chn_radio538.py
@@ -173,7 +173,7 @@ class Channel(chn_class.Channel):
                                         "&pname=TDSdk&pversion=2.9&banners=none")
         slam_fm.media_type = mediatype.AUDIO
         slam_fm.isLive = True
-        slam_fm.append_single_stream(slam_fm.url)
+        slam_fm.add_stream(slam_fm.url)
         slam_fm.complete = True
         items.append(slam_fm)
 

--- a/channels/channel.streams/radio538/chn_radio538.py
+++ b/channels/channel.streams/radio538/chn_radio538.py
@@ -317,10 +317,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -369,10 +369,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.uk/bbc/chn_bbc.py
+++ b/channels/channel.uk/bbc/chn_bbc.py
@@ -245,8 +245,6 @@ class Channel(chn_class.Channel):
         # /2.0/mediaset/pc/vpid/%s/atk/2214e42b5729dcdd012dfb61a3054d39309ccd31/asn/1/
         # And I don't know where that one comes from
 
-        part = item.create_new_empty_media_part()
-
         stream_data = UriHandler.open(stream_data_url)
         # Reroute for debugging
         # from debug.router import Router
@@ -309,9 +307,9 @@ class Channel(chn_class.Channel):
                     continue
 
                 if transfer_format == "hls":
-                    item.complete = M3u8.update_part_with_m3u8_streams(part, url, bitrate=stream_bitrate)
+                    item.complete = M3u8.update_part_with_m3u8_streams(item, url, bitrate=stream_bitrate)
                 elif transfer_format == "dash":
-                    strm = part.append_media_stream(url, bitrate)
+                    strm = item.add_stream(url, bitrate)
                     Mpd.set_input_stream_addon_input(strm)
 
         # get the subtitle
@@ -321,7 +319,7 @@ class Channel(chn_class.Channel):
         if len(subtitles) > 0:
             subtitle = subtitles[0]
             subtitle_url = "%s%s" % (subtitle[0], subtitle[1])
-            part.Subtitle = subtitlehelper.SubtitleHelper.download_subtitle(
+            item.subtitle = subtitlehelper.SubtitleHelper.download_subtitle(
                 subtitle_url, subtitle[1], "ttml")
 
         item.complete = True
@@ -509,10 +507,9 @@ class Channel(chn_class.Channel):
         stream_root = Regexer.do_regex(r'<media href="([^"]+\.isml)', data)[0]
         Logger.debug("Found Live stream root: %s", stream_root)
 
-        part = item.create_new_empty_media_part()
         for s, b in F4m.get_streams_from_f4m(item.url):
             item.complete = True
             s = s.replace(".f4m", ".m3u8")
-            part.append_media_stream(s, b)
+            item.add_stream(s, b)
 
         return item

--- a/channels/channel.uk/bbc/chn_bbc.py
+++ b/channels/channel.uk/bbc/chn_bbc.py
@@ -216,10 +216,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -489,10 +489,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.videos/amt/chn_amt.py
+++ b/channels/channel.videos/amt/chn_amt.py
@@ -162,8 +162,7 @@ class Channel(chn_class.Channel):
             duration = (int(runtime[0]) * 60) + int(runtime[1])
             item.set_info_label("duration", duration)
 
-        part = item.create_new_empty_media_part()
-        part.HttpHeaders["User-Agent"] = "QuickTime/7.6 (qtver=7.6;os=Windows NT 6.0Service Pack 2)"
+        stream_headers = {"User-Agent": "QuickTime/7.6 (qtver=7.6;os=Windows NT 6.0Service Pack 2)"}
 
         if "versions" in result_set and "enus" in result_set["versions"] and "sizes" in result_set["versions"]["enus"]:
             streams = result_set["versions"]["enus"]["sizes"]
@@ -183,9 +182,10 @@ class Channel(chn_class.Channel):
                             if len(parts) == 2:
                                 Logger.trace(parts)
                                 stream_url = "%s_h%s" % (parts[0], parts[1])
-                            part.append_media_stream(stream_url, bitrate)
+                            stream = item.add_stream(stream_url, bitrate)
                         else:
-                            part.append_media_stream(stream_url, bitrate)
+                            stream = item.add_stream(stream_url, bitrate)
+                        stream.HttpHeaders.update(stream_headers)
                         item.complete = True
 
         return item

--- a/channels/channel.videos/channel9/chn_channel9.py
+++ b/channels/channel.videos/channel9/chn_channel9.py
@@ -264,7 +264,6 @@ class Channel(chn_class.Channel):
         data = UriHandler.open(item.url)
 
         urls = Regexer.do_regex('<a href="([^"]+.(?:wmv|mp4))">(High|Medium|Mid|Low|MP4)', data)
-        media_part = item.create_new_empty_media_part()
         for url in urls:
             if url[1].lower() == "high":
                 bitrate = 2000
@@ -274,7 +273,7 @@ class Channel(chn_class.Channel):
                 bitrate = 200
             else:
                 bitrate = 0
-            media_part.append_media_stream(HtmlEntityHelper.convert_html_entities(url[0]), bitrate)
+            item.add_stream(HtmlEntityHelper.convert_html_entities(url[0]), bitrate)
 
         item.complete = True
         return item

--- a/channels/channel.videos/channel9/chn_channel9.py
+++ b/channels/channel.videos/channel9/chn_channel9.py
@@ -245,10 +245,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.videos/dumpert/chn_dumpert.py
+++ b/channels/channel.videos/dumpert/chn_dumpert.py
@@ -105,7 +105,6 @@ class Channel(chn_class.Channel):
             item.set_date(*[int(i) for i in date_tuple])
 
         if "media" in result_set and result_set["media"]:
-            part = item.create_new_empty_media_part()
             for video_info in result_set["media"]:
                 if video_info["mediatype"] == "FOTO":
                     Logger.trace("Ignoring foto: %s", item)
@@ -116,21 +115,21 @@ class Channel(chn_class.Channel):
                     uri = info["uri"]
 
                     if video_type == "flv":
-                        part.append_media_stream(uri, 1000)
+                        item.add_stream(uri, 1000)
                     elif video_type == "720p":
-                        part.append_media_stream(uri, 1200)
+                        item.add_stream(uri, 1200)
                     elif video_type == "1080p" or video_type == "original":
-                        part.append_media_stream(uri, 1600)
+                        item.add_stream(uri, 1600)
                     elif video_type == "tablet":
-                        part.append_media_stream(uri, 800)
+                        item.add_stream(uri, 800)
                     elif video_type == "mobile":
-                        part.append_media_stream(uri, 450)
+                        item.add_stream(uri, 450)
                     elif video_type == "embed" and uri.startswith("youtube"):
                         embed_type, youtube_id = uri.split(":")
                         url = "https://www.youtube.com/watch?v=%s" % (youtube_id, )
                         for s, b in YouTube.get_streams_from_you_tube(url):
                             item.complete = True
-                            part.append_media_stream(s, b)
+                            item.add_stream(s, b)
                     else:
                         Logger.warning("Video type '%s' was not used", video_type)
             item.complete = True

--- a/channels/channel.videos/eredivisie/chn_eredivisie.py
+++ b/channels/channel.videos/eredivisie/chn_eredivisie.py
@@ -176,10 +176,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.videos/eredivisie/chn_eredivisie.py
+++ b/channels/channel.videos/eredivisie/chn_eredivisie.py
@@ -233,8 +233,7 @@ class Channel(chn_class.Channel):
                                           notification_type=XbmcWrapper.Error, display_time=5000)
 
         license_url = stream_info.get_value("LicenseURL")
-        part = item.create_new_empty_media_part()
-        stream = part.append_media_stream(stream_url, 0)
+        stream = item.add_stream(stream_url, 0)
         license_key = Mpd.get_license_key(license_url)
         Mpd.set_input_stream_addon_input(stream, license_key=license_key)
         return item

--- a/channels/channel.videos/extreme/chn_extreme.py
+++ b/channels/channel.videos/extreme/chn_extreme.py
@@ -98,11 +98,10 @@ class Channel(chn_class.Channel):
         you_tube_url = Regexer.do_regex('"(https://www.youtube.com/embed/[^\"]+)', data)
         if you_tube_url:
             Logger.debug("Using Youtube video")
-            part = item.create_new_empty_media_part()
             you_tube_url = you_tube_url[0].replace("embed/", "watch?v=")
             for s, b in YouTube.get_streams_from_you_tube(you_tube_url):
                 item.complete = True
-                part.append_media_stream(s, b)
+                item.add_stream(s, b)
             return item
 
         guid = Regexer.do_regex(
@@ -116,14 +115,13 @@ class Channel(chn_class.Channel):
             base_url = smiller.get_base_url()
             urls = smiller.get_videos_and_bitrates()
 
-            part = item.create_new_empty_media_part()
             for url in urls:
                 if "youtube" in url[0]:
                     for s, b in YouTube.get_streams_from_you_tube(url[0]):
                         item.complete = True
-                        part.append_media_stream(s, b)
+                        item.add_stream(s, b)
                 else:
-                    part.append_media_stream("%s%s" % (base_url, url[0]), bitrate=int(url[1]) // 1000)
+                    item.add_stream("%s%s" % (base_url, url[0]), bitrate=int(url[1]) // 1000)
                 item.complete = True
 
             Logger.trace("update_video_item complete: %s", item)

--- a/channels/channel.videos/extreme/chn_extreme.py
+++ b/channels/channel.videos/extreme/chn_extreme.py
@@ -73,10 +73,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.videos/hardwareinfo/chn_hardwareinfo.py
+++ b/channels/channel.videos/hardwareinfo/chn_hardwareinfo.py
@@ -243,10 +243,9 @@ class Channel(chn_class.Channel):
 
         """
 
-        part = item.create_new_empty_media_part()
         for s, b in YouTube.get_streams_from_you_tube(item.url):
             item.complete = True
-            part.append_media_stream(s, b)
+            item.add_stream(s, b)
 
         item.complete = True
         return item

--- a/channels/channel.videos/hardwareinfo/chn_hardwareinfo.py
+++ b/channels/channel.videos/hardwareinfo/chn_hardwareinfo.py
@@ -230,10 +230,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.videos/ons/chn_ons.py
+++ b/channels/channel.videos/ons/chn_ons.py
@@ -84,13 +84,12 @@ class Channel(chn_class.Channel):
         data = UriHandler.open(item.url)
         json_data = JsonHelper(data)
         streams = json_data.get_value("clip", "previews")
-        part = item.create_new_empty_media_part()
         for stream_info in streams:
             name = stream_info["name"]
             # for now we only take the numbers as bitrate:
             bitrate = int(''.join([x for x in name if x.isdigit()]))
             url = stream_info["source"]
-            part.append_media_stream(url, bitrate)
+            item.add_stream(url, bitrate)
             item.complete = True
 
         return item

--- a/channels/channel.videos/ons/chn_ons.py
+++ b/channels/channel.videos/ons/chn_ons.py
@@ -65,10 +65,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.videos/pathenl/chn_pathenl.py
+++ b/channels/channel.videos/pathenl/chn_pathenl.py
@@ -243,7 +243,7 @@ class Channel(chn_class.Channel):
         if item.thumb:
             item.thumb = item.thumb.replace(" ", "%20")
         item.fanart = item.thumb
-        item.append_single_stream(result_set['filename'])
+        item.add_stream(result_set['filename'])
         item.complete = True
         item.HttpHeaders = self.httpHeaders
         return item
@@ -420,7 +420,7 @@ class Channel(chn_class.Channel):
 
         for video in videos:
             Logger.trace(video)
-            item.append_single_stream(video)
+            item.add_stream(video)
         
         item.complete = True
         return item

--- a/channels/channel.videos/pathenl/chn_pathenl.py
+++ b/channels/channel.videos/pathenl/chn_pathenl.py
@@ -396,10 +396,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.

--- a/channels/channel.videos/twit/chn_twit.py
+++ b/channels/channel.videos/twit/chn_twit.py
@@ -80,7 +80,6 @@ class Channel(chn_class.Channel):
         playback_item = MediaItem("Play Live", "http://live.twit.tv/")
         playback_item.media_type = mediatype.VIDEO
         playback_item.isLive = True
-        playback_part = playback_item.create_new_empty_media_part()
 
         # noinspection PyStatementEffect
         """
@@ -124,9 +123,9 @@ class Channel(chn_class.Channel):
         }
 
         for bitrate in media_urls:
-            playback_part.append_media_stream(media_urls[bitrate], bitrate)
+            item.add_stream(media_urls[bitrate], int(bitrate))
 
-        Logger.debug("Streams: %s", playback_part)
+        Logger.debug("Streams: %s", item.streams)
         playback_item.complete = True
         item.items.append(playback_item)
         Logger.debug("Appended: %s", playback_item)
@@ -203,10 +202,10 @@ class Channel(chn_class.Channel):
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -222,10 +221,9 @@ class Channel(chn_class.Channel):
         streams = Regexer.do_regex(self.mediaUrlRegex, data)
 
         item.MediaItemParts = []
-        part = item.create_new_empty_media_part()
         for stream in streams:
             Logger.trace(stream)
-            part.append_media_stream(stream[0], stream[1])
+            item.add_stream(stream[0], stream[1])
 
         item.complete = True
         return item

--- a/channels/channel.videos/twit/chn_twit.py
+++ b/channels/channel.videos/twit/chn_twit.py
@@ -220,7 +220,7 @@ class Channel(chn_class.Channel):
         data = UriHandler.open(item.url)
         streams = Regexer.do_regex(self.mediaUrlRegex, data)
 
-        item.MediaItemParts = []
+        item.streams = []
         for stream in streams:
             Logger.trace(stream)
             item.add_stream(stream[0], stream[1])

--- a/resources/lib/actions/videoaction.py
+++ b/resources/lib/actions/videoaction.py
@@ -51,12 +51,12 @@ class VideoAction(AddonAction):
             self.__show_warnings(media_item)
 
             # validated the updated media_item
-            if not media_item.complete or not media_item.has_media_item_parts():
+            if not media_item.complete or not media_item.has_streams():
                 Logger.warning(
                     "process_video_item returned an MediaItem that had MediaItem.complete = False:\n%s",
                     media_item)
 
-            if not media_item.has_media_item_parts():
+            if not media_item.has_streams():
                 # the update failed or no items where found. Don't play
                 XbmcWrapper.show_notification(
                     LanguageHelper.get_localized_string(LanguageHelper.ErrorId),
@@ -67,12 +67,12 @@ class VideoAction(AddonAction):
                 xbmcplugin.endOfDirectory(self.handle, False)
                 return
 
-            kodi_items = media_item.get_kodi_play_list_data(
+            kodi_item, start_url = media_item.get_resolved_kodi_item(
                 AddonSettings.get_max_stream_bitrate(self.__channel)
             )
 
             Logger.debug("Continuing playback in plugin.py")
-            if not bool(kodi_items):
+            if not bool(kodi_item):
                 Logger.warning("play_video_item did not return valid playdata")
                 xbmcplugin.endOfDirectory(self.handle, False)
                 return
@@ -81,14 +81,15 @@ class VideoAction(AddonAction):
             # setResolved will not work.
             LockWithDialog.close_busy_dialog()
 
-            # Append it to the Kodi playlist in a smart way.
-            start_url = self.__append_kodi_play_list(kodi_items)
+            # Set the resolved url
+            Logger.debug("Setting resolved item: %s", media_item)
+            xbmcplugin.setResolvedUrl(self.handle, True, kodi_item)
 
             # Set the mode (if the InputStream Adaptive add-on is used, we also need to set it)
             show_subs = AddonSettings.show_subtitles()
 
             # TODO: Apparently if we use the InputStream Adaptive, using the setSubtitles() causes sync issues.
-            available_subs = [p.Subtitle for p in media_item.MediaItemParts]
+            available_subs = media_item.subtitle
 
             # Get the Kodi Player instance (let Kodi decide what player, see
             # http://forum.kodi.tv/showthread.php?tid=173887&pid=1516662#pid1516662)
@@ -132,40 +133,6 @@ class VideoAction(AddonAction):
                 title = LanguageHelper.get_localized_string(LanguageHelper.PaidTitle)
                 message = LanguageHelper.get_localized_string(LanguageHelper.PaidText)
                 XbmcWrapper.show_dialog(title, message)
-
-    def __append_kodi_play_list(self, kodi_items):
-        # Get the current playlist
-        play_list = xbmc.PlayList(xbmc.PLAYLIST_VIDEO)
-        play_list_size = play_list.size()
-        start_index = play_list.getposition()  # the current location
-        if start_index < 0:
-            start_index = 0
-        Logger.debug("Current playlist size and position: %s @ %s", play_list_size, start_index)
-
-        current_play_list_items = [play_list[i] for i in range(0, len(play_list))]
-        play_list.clear()
-        for i in range(0, start_index):
-            Logger.debug("Adding existing PlayList item")
-            play_list.add(current_play_list_items[i].getPath(), current_play_list_items[i])
-
-        # The current item to play (we need to store te starting url for later)
-        Logger.debug("Adding Main PlayList item")
-        kodi_item, start_url = kodi_items.pop(0)
-        play_list.add(start_url, kodi_item, start_index)
-        xbmcplugin.setResolvedUrl(self.handle, True, kodi_item)
-
-        # now we add the rest of the Kodi ListItems for the other parts
-        for kodi_item, stream_url in kodi_items:
-            Logger.debug("Adding Additional PlayList item")
-            play_list.add(stream_url, kodi_item, start_index)
-            xbmcplugin.setResolvedUrl(self.handle, True, kodi_item)
-
-        # add the remaining items
-        for i in range(start_index + 1, len(current_play_list_items)):
-            Logger.debug("Adding existing PlayList item")
-            play_list.add(current_play_list_items[i].getPath(), current_play_list_items[i])
-
-        return start_url
 
     def __call_upnext(self, media_item):
         """ Calls UpNext to send information on the next episode.

--- a/resources/lib/actions/videoaction.py
+++ b/resources/lib/actions/videoaction.py
@@ -82,14 +82,13 @@ class VideoAction(AddonAction):
             LockWithDialog.close_busy_dialog()
 
             # Set the resolved url
-            Logger.debug("Setting resolved item: %s", media_item)
             xbmcplugin.setResolvedUrl(self.handle, True, kodi_item)
 
             # Set the mode (if the InputStream Adaptive add-on is used, we also need to set it)
             show_subs = AddonSettings.show_subtitles()
 
             # TODO: Apparently if we use the InputStream Adaptive, using the setSubtitles() causes sync issues.
-            available_subs = media_item.subtitle
+            available_subs = [media_item.subtitle]
 
             # Get the Kodi Player instance (let Kodi decide what player, see
             # http://forum.kodi.tv/showthread.php?tid=173887&pid=1516662#pid1516662)

--- a/resources/lib/chn_class.py
+++ b/resources/lib/chn_class.py
@@ -9,7 +9,7 @@ else:
     # noinspection PyUnresolvedReferences
     import urllib.parse as parse
 
-from resources.lib.mediaitem import MediaItem, MediaItemPart, FolderItem
+from resources.lib.mediaitem import MediaItem, FolderItem, MediaStream
 from resources.lib import contenttype
 from resources.lib import mediatype
 from resources.lib.regexer import Regexer
@@ -733,10 +733,10 @@ class Channel:
 
         The method should at least:
         * cache the thumbnail to disk (use self.noImage if no thumb is available).
-        * set at least one MediaItemPart with a single MediaStream.
+        * set at least one MediaStream.
         * set self.complete = True.
 
-        if the returned item does not have a MediaItemPart then the self.complete flag
+        if the returned item does not have a MediaSteam then the self.complete flag
         will automatically be set back to False.
 
         :param MediaItem item: the original MediaItem that needs updating.
@@ -751,8 +751,8 @@ class Channel:
         data = UriHandler.open(item.url, additional_headers=item.HttpHeaders)
 
         url = Regexer.do_regex(self.mediaUrlRegex, data)[-1]
-        part = MediaItemPart(item.name, url)
-        item.MediaItemParts.append(part)
+        stream = MediaStream(url)
+        item.streams.append(stream)
 
         Logger.info('finishing update_video_item. MediaItems are %s', item)
 
@@ -760,7 +760,7 @@ class Channel:
             # no thumb was set yet and no url
             Logger.debug("Setting thumb to %s", item.thumb)
 
-        if not item.has_media_item_parts():
+        if not item.has_streams():
             item.complete = False
         else:
             item.complete = True

--- a/resources/lib/mediaitem.py
+++ b/resources/lib/mediaitem.py
@@ -128,10 +128,12 @@ class MediaItem:
 
         """
 
-        self.subtitle = subtitle
-
         stream = MediaStream(url, bitrate)
         self.streams.append(stream)
+
+        if subtitle:
+            self.subtitle = subtitle
+
         return stream
 
     def has_streams(self):
@@ -684,6 +686,9 @@ class MediaItem:
         else:
             value = "%s [Type=%s, Url=%s, Date=%s, IsLive=%s, Geo/DRM=%s/%s]" \
                     % (value, self.media_type, self.url, self.__date, self.isLive, self.isGeoLocked, self.isDrmProtected)
+
+        if self.subtitle:
+            value = "%s\n + Subtitle: %s" % (value, self.subtitle)
 
         return value
 

--- a/resources/lib/mediaitem.py
+++ b/resources/lib/mediaitem.py
@@ -22,19 +22,13 @@ from resources.lib.proxyinfo import ProxyInfo
 
 # Don't make this an MediaItem(object) as it breaks the pickles
 class MediaItem:
-    """Main class that represent items that are retrieved in XOT. They are used
-    to fill the lists and have MediaItemParts which have MediaStreams in this
-    hierarchy:
+    """Main class that represent items that are retrieved in Retrospect. They are used
+    to fill the lists and have MediaStreams in this hierarchy:
 
     MediaItem
-        +- MediaItemPart
-        |    +- MediaStream
-        |    +- MediaStream
-        |    +- MediaStream
-        +- MediaItemPart
-        |    +- MediaStream
-        |    +- MediaStream
-        |    +- MediaStream
+        +- MediaStream
+        +- MediaStream
+        +- MediaStream
 
     """
 
@@ -69,7 +63,7 @@ class MediaItem:
         self.tv_show_title = tv_show_title
         self.url = url
         self.actionUrl = None
-        self.MediaItemParts = []
+
         self.description = ""
         self.thumb = ""                           # : The thumbnail (16:9, min 520x293)
         self.fanart = ""                          # : The fanart url (16:9, min 720p)
@@ -103,6 +97,9 @@ class MediaItem:
         # musicvideos, videos, images, games. Defaults to 'episodes'
         self.content_type = contenttype.EPISODES
 
+        self.streams = []  # type: list[MediaStream]
+        self.subtitle = None
+
         if depickle:
             # While deplickling we don't need to do the guid/guidValue calculations. They will
             # be set from the __setstate__()
@@ -117,57 +114,35 @@ class MediaItem:
             self.guid = self.__get_uuid()
         self.guidValue = int("0x%s" % (self.guid,), 0)
 
-    def append_single_stream(self, url, bitrate=0, subtitle=None):
-        """ Appends a single stream to a new MediaPart of this MediaItem.
+    def add_stream(self, url, bitrate=0, subtitle=None):
+        """ Appends a single stream to  this MediaItem.
 
-        This methods creates a new MediaPart item and adds the provided
-        stream to its MediaStreams collection. The newly created MediaPart
-        is then added to the MediaItem's MediaParts collection.
+        This methods adds a new MediaStream the MediaItem's streams collection.
 
         :param str url:         Url of the stream.
         :param int bitrate:     Bitrate of the stream (default = 0).
-        :param str subtitle:    Url of the subtitle of the mediapart.
+        :param str subtitle:    Url of the subtitle of the this Mediaitem..
 
-        :return: A reference to the created MediaPart.
-        :rtype: MediaItemPart
-
-        """
-
-        new_part = MediaItemPart(self.name, url, bitrate, subtitle)
-        self.MediaItemParts.append(new_part)
-        return new_part
-
-    def create_new_empty_media_part(self):
-        """ Adds an empty MediaPart to the MediaItem.
-
-        This method is used to create an empty MediaPart that can be used to
-        add new stream to. The newly created MediaPart is appended to the
-        MediaItem.MediaParts list.
-
-        :return: The new MediaPart object (as a reference) that was appended.
-        :rtype: MediaItemPart
+        :return: A reference to the created MediaStream.
+        :rtype: MediaStream
 
         """
 
-        new_part = MediaItemPart(self.name)
-        self.MediaItemParts.append(new_part)
-        return new_part
+        self.subtitle = subtitle
 
-    def has_media_item_parts(self):
-        """ Return True if there are any MediaItemParts present with streams for
-        this MediaItem
+        stream = MediaStream(url, bitrate)
+        self.streams.append(stream)
+        return stream
 
-        :return: True if there are any MediaItemParts present with streams for
-                 this MediaItem
+    def has_streams(self):
+        """ Return True if there are any MediaStreams present for this MediaItem
+
+        :return: True if there are any MediaStreams present this MediaItem
         :rtype: bool
 
         """
 
-        for part in self.MediaItemParts:
-            if len(part.MediaStreams) > 0:
-                return True
-
-        return False
+        return len(self.streams) > 0
 
     @property
     def is_playable(self):
@@ -500,71 +475,67 @@ class MediaItem:
         item.setContentLookup(False)
         return item
 
-    def get_kodi_play_list_data(self, bitrate, proxy=None):
-        """ Returns the playlist items for this MediaItem
+    def get_resolved_kodi_item(self, bitrate, proxy=None):
+        """ Retrieves a resolved kodi ListItem.
 
         :param int bitrate:             The bitrate of the streams that should be in the
                                         playlist. Given in kbps.
         :param ProxyInfo|None proxy:    The proxy to set
 
-        :return: A list of ListItems that should be added to a playlist with their selected
-                 stream url
-        :rtype: list[tuple[xbmcgui.ListItem, str]]
+        :return: A Kodi ListItem with a resolved path and that path.
+        :rtype: tuple[xbmcgui.ListItem, str]
 
         """
 
-        Logger.info("Creating playlist items for Bitrate: %s kbps\n%s\nMediaType: %s",
+        Logger.info("Creating a Kodi ListItem for Bitrate: %s kbps\n%s\nMediaType: %s",
                     bitrate, self, self.media_type)
 
         if bitrate is None:
             raise ValueError("Bitrate not specified")
 
-        play_list_data = []
-        for part in self.MediaItemParts:
-            if len(part.MediaStreams) == 0:
-                Logger.warning("Ignoring empty MediaPart: %s", part)
-                continue
+        if len(self.streams) == 0:
+            Logger.warning("Ignoring empty MediaItem: %s", self)
+            return None, None
 
-            kodi_item = self.get_kodi_item()
-            stream = part.get_media_stream_for_bitrate(bitrate)
-            if stream.Adaptive and bitrate > 0:
-                Adaptive.set_max_bitrate(stream, max_bit_rate=bitrate)
+        kodi_item = self.get_kodi_item()
 
-            # Set the actual stream path
-            kodi_item.setProperty("path", stream.Url)
+        stream = self.__get_matching_stream(bitrate=bitrate)
+        if stream.Adaptive and bitrate > 0:
+            Adaptive.set_max_bitrate(stream, max_bit_rate=bitrate)
 
-            # properties of the Part
-            for prop in part.Properties + stream.Properties:
-                Logger.trace("Adding property: %s", prop)
-                kodi_item.setProperty(prop[0], prop[1])
+        # Set the actual stream path
+        kodi_item.setPath(path=stream.Url)
 
-            # TODO: Apparently if we use the InputStream Adaptive, using the setSubtitles() causes sync issues.
-            if part.Subtitle and False:
-                Logger.debug("Adding subtitle to ListItem: %s", part.Subtitle)
-                kodi_item.setSubtitles([part.Subtitle, ])
+        # properties of the Part
+        for prop in stream.Properties:
+            Logger.trace("Adding property: %s", prop)
+            kodi_item.setProperty(prop[0], prop[1])
 
-            # Set any custom Header
-            header_params = dict()
+        # TODO: Apparently if we use the InputStream Adaptive, using the setSubtitles() causes sync issues.
+        if self.subtitle and False:
+            Logger.debug("Adding subtitle to ListItem: %s", self.subtitle)
+            kodi_item.setSubtitles([self.subtitle, ])
 
-            # set proxy information if present
-            self.__set_kodi_proxy_info(kodi_item, stream, stream.Url, header_params, proxy)
+        # Set any custom Header
+        header_params = dict()
 
-            # Now add the actual HTTP headers
-            for k in part.HttpHeaders:
-                header_params[k] = HtmlEntityHelper.url_encode(part.HttpHeaders[k])
+        # set proxy information if present
+        self.__set_kodi_proxy_info(kodi_item, stream, stream.Url, header_params, proxy)
 
-            stream_url = stream.Url
-            if header_params:
-                kodi_query_string = reduce(
-                    lambda x, y: "%s&%s=%s" % (x, y, header_params[y]), header_params.keys(), "")
-                kodi_query_string = kodi_query_string.lstrip("&")
-                Logger.debug("Adding Kodi Stream parameters: %s\n%s", header_params, kodi_query_string)
-                stream_url = "%s|%s" % (stream.Url, kodi_query_string)
+        # Now add the actual HTTP headers
+        for k in stream.HttpHeaders:
+            header_params[k] = HtmlEntityHelper.url_encode(stream.HttpHeaders[k])
 
-            Logger.info("Playing Stream:  %s", stream)
-            play_list_data.append((kodi_item, stream_url))
+        stream_url = stream.Url
+        if header_params:
+            kodi_query_string = reduce(
+                lambda x, y: "%s&%s=%s" % (x, y, header_params[y]), header_params.keys(), "")
+            kodi_query_string = kodi_query_string.lstrip("&")
+            Logger.debug("Adding Kodi Stream parameters: %s\n%s", header_params, kodi_query_string)
+            stream_url = "%s|%s" % (stream.Url, kodi_query_string)
 
-        return play_list_data
+        Logger.info("Playing Stream: %s", stream)
+        return kodi_item, stream_url
 
     @property
     def uses_external_addon(self):
@@ -573,6 +544,54 @@ class MediaItem:
     @property
     def title(self):
         return self.name
+
+    def __get_matching_stream(self, bitrate):
+        """ Returns the MediaStream for the requested bitrate.
+
+        Arguments:
+        bitrate : integer - The bitrate of the stream in kbps
+
+        Returns:
+        The url of the stream with the requested bitrate.
+
+        If bitrate is not specified the highest bitrate stream will be used.
+
+        """
+
+        # order the items by bitrate
+        self.streams.sort(key=lambda s: s.Bitrate)
+        best_stream = None
+        best_distance = None
+
+        if bitrate == 0:
+            # return the highest one
+            Logger.debug("Returning the higest bitrate stream")
+            return self.streams[-1]
+
+        for stream in self.streams:
+            if stream.Bitrate is None:
+                # no bitrate set, see if others are available
+                continue
+
+            # this is the bitrate-as-max-limit-method
+            if stream.Bitrate > bitrate:
+                # if the bitrate is higher, continue for more
+                continue
+            # if commented ^^ , we get the closest-match-method
+
+            # determine the distance till the bitrate
+            distance = abs(bitrate - stream.Bitrate)
+
+            if best_distance is None or best_distance > distance:
+                # this stream is better, so store it.
+                best_distance = distance
+                best_stream = stream
+
+        if best_stream is None:
+            # no match, take the lowest bitrate
+            return self.streams[0]
+
+        return best_stream
 
     def __set_kodi_proxy_info(self, kodi_item, stream, stream_url, kodi_params, proxy):
         """ Updates a Kodi ListItem with the correct Proxy configuration taken from the ProxyInfo
@@ -651,12 +670,12 @@ class MediaItem:
         value = self.name
 
         if self.is_playable:
-            if len(self.MediaItemParts) > 0:
+            if len(self.streams) > 0:
                 value = "MediaItem: %s [Type=%s, Complete=%s, IsLive=%s, Date=%s, Geo/DRM=%s/%s]" % \
                         (value, self.media_type, self.complete, self.isLive, self.__date,
                          self.isGeoLocked, self.isDrmProtected)
-                for media_part in self.MediaItemParts:
-                    value = "%s\n%s" % (value, media_part)
+                for media_stream in self.streams:
+                    value = "%s\n%s" % (value, media_stream)
                 value = "%s" % (value,)
             else:
                 value = "%s [Type=%s, Complete=%s, unknown urls, IsLive=%s, Date=%s, Geo/DRM=%s/%s]" \
@@ -884,186 +903,6 @@ class FolderItem(MediaItem):
 
 
 # Don't make this an MediaItem(object) as it breaks the pickles
-class MediaItemPart:
-    """Class that represents a MediaItemPart"""
-
-    def __init__(self, name, url="", bitrate=0, subtitle=None, *args):
-        """ Creates a MediaItemPart with <name> with at least one MediaStream
-        instantiated with the values <url> and <bitrate>.
-        The MediaPart could also have a <subtitle> or Properties in the <*args>
-
-        If a subtitles was provided, the subtitle will be downloaded and stored
-        in the XOT cache. When played, the subtitle is shown. Due to the Kodi
-        limitation only one subtitle can be set on a playlist, this will be
-        the subtitle of the first MediaPartItem
-
-        :param str name:                    The name of the MediaItemPart.
-        :param str url:                     The URL of the stream of the MediaItemPart.
-        :param int bitrate:                 The bitrate of the stream of the MediaItemPart.
-        :param str|None subtitle:           The url of the subtitle of this MediaItemPart
-        :param tuple[str,str] args:         A list of arguments that will be set as properties
-                                            when getting an Kodi Playlist Item
-
-        """
-
-        Logger.trace("Creating MediaItemPart '%s' for '%s'", name, url)
-        self.Name = name
-        self.MediaStreams = []
-        self.Subtitle = ""
-        self.HttpHeaders = dict()                   # :  HTTP Headers for stream playback
-
-        # set a subtitle
-        if subtitle is not None:
-            self.Subtitle = subtitle
-
-        if not url == "":
-            # set the stream that was passed
-            self.append_media_stream(url, bitrate)
-
-        # set properties
-        self.Properties = []
-        for prop in args:
-            self.add_property(prop[0], prop[1])
-        return
-
-    def append_media_stream(self, url, bitrate, *args):
-        """Appends a mediastream item to the current MediaPart
-
-        The bitrate could be set to None.
-
-        :param url:                     The url of the MediaStream.
-        :param int|str bitrate:         The bitrate of the MediaStream.
-        :param tuple[str,str] args:     A list of arguments that will be set as properties
-                                        when getting an Kodi Playlist Item
-
-        :return: The newly added MediaStream by reference.
-        :rtype: MediaStream
-
-        """
-
-        stream = MediaStream(url, bitrate, *args)
-        self.MediaStreams.append(stream)
-        return stream
-
-    def add_property(self, name, value):
-        """ Adds a property to the MediaPart.
-
-        Appends a new property to the self.Properties dictionary. On playback
-        these properties will be set to the Kodi PlaylistItem as properties.
-
-        :param str name:    The name of the property.
-        :param str value:   The value of the property.
-
-        """
-
-        Logger.debug("Adding property: %s = %s", name, value)
-        self.Properties.append((name, value))
-
-    def get_media_stream_for_bitrate(self, bitrate):
-        """Returns the MediaStream for the requested bitrate.
-
-        Arguments:
-        bitrate : integer - The bitrate of the stream in kbps
-
-        Returns:
-        The url of the stream with the requested bitrate.
-
-        If bitrate is not specified the highest bitrate stream will be used.
-
-        """
-
-        # order the items by bitrate
-        self.MediaStreams.sort(key=lambda s: s.Bitrate)
-        best_stream = None
-        best_distance = None
-
-        if bitrate == 0:
-            # return the highest one
-            Logger.debug("Returning the higest bitrate stream")
-            return self.MediaStreams[-1]
-
-        for stream in self.MediaStreams:
-            if stream.Bitrate is None:
-                # no bitrate set, see if others are available
-                continue
-
-            # this is the bitrate-as-max-limit-method
-            if stream.Bitrate > bitrate:
-                # if the bitrate is higher, continue for more
-                continue
-            # if commented ^^ , we get the closest-match-method
-
-            # determine the distance till the bitrate
-            distance = abs(bitrate - stream.Bitrate)
-
-            if best_distance is None or best_distance > distance:
-                # this stream is better, so store it.
-                best_distance = distance
-                best_stream = stream
-
-        if best_stream is None:
-            # no match, take the lowest bitrate
-            return self.MediaStreams[0]
-
-        return best_stream
-
-    def __eq__(self, other):
-        """ Checks 2 items for Equality. Equality takes into consideration:
-
-        * Name
-        * Subtitle
-        * Length of the MediaStreams
-        * Compares all the MediaStreams in the self.MediaStreams
-
-         :param MediaItemPart other: The part the test for equality.
-
-         :return: Returns true if the items are equal.
-         :rtype: bool
-
-        """
-
-        if other is None:
-            return False
-
-        if not other.Name == self.Name:
-            return False
-
-        if not other.Subtitle == self.Subtitle:
-            return False
-
-        # now check the stream
-        if not len(self.MediaStreams) == len(other.MediaStreams):
-            return False
-
-        for i in range(0, len(self.MediaStreams)):
-            if not self.MediaStreams[i] == other.MediaStreams[i]:
-                return False
-
-        # if we reach this point they are equal.
-        return True
-
-    def __str__(self):
-        """ String representation for the MediaPart
-
-        :return: The String representation
-        :rtype: str
-
-        """
-
-        text = "MediaPart: %s [HttpHeaders=%s]" % (self.Name, self.HttpHeaders)
-
-        if self.Subtitle != "":
-            text = "%s\n + Subtitle: %s" % (text, self.Subtitle)
-
-        for prop in self.Properties:
-            text = "%s\n + Property: %s=%s" % (text, prop[0], prop[1])
-
-        for stream in self.MediaStreams:
-            text = "%s\n + %s" % (text, stream)
-        return text
-
-
-# Don't make this an MediaItem(object) as it breaks the pickles
 class MediaStream:
     """Class that represents a Mediastream with <url> and a specific <bitrate>"""
 
@@ -1081,6 +920,7 @@ class MediaStream:
         self.Bitrate = int(bitrate)
         self.Properties = []
         self.Adaptive = False
+        self.HttpHeaders = dict()  # :  HTTP Headers for stream playback
 
         for prop in args:
             self.add_property(prop[0], prop[1])

--- a/resources/lib/streams/adaptive.py
+++ b/resources/lib/streams/adaptive.py
@@ -79,8 +79,7 @@ class Adaptive(object):
 
         Can be used like this:
 
-            part = item.create_new_empty_media_part()
-            stream = part.append_media_stream(stream_url, 0)
+            stream = item.add_stream(stream_url, 0)
             M3u8.set_input_stream_addon_input(stream, self.headers)
             item.complete = True
 

--- a/resources/lib/streams/f4m.py
+++ b/resources/lib/streams/f4m.py
@@ -19,11 +19,10 @@ class F4m(object):
 
         Can be used like this:
 
-            part = item.create_new_empty_media_part()
             for s, b in F4m.get_streams_from_f4m(url):
                 item.complete = True
                 # s = self.get_verifiable_video_url(s)
-                part.append_media_stream(s, b)
+                item.add_stream(s, b)
 
         """
 

--- a/resources/lib/streams/m3u8.py
+++ b/resources/lib/streams/m3u8.py
@@ -4,7 +4,7 @@ from resources.lib.urihandler import UriHandler
 from resources.lib.logger import Logger
 from resources.lib.regexer import Regexer
 from resources.lib.streams.adaptive import Adaptive
-from resources.lib.mediaitem import MediaItemPart, MediaStream
+from resources.lib.mediaitem import MediaStream, MediaItem
 from resources.lib.addonsettings import AddonSettings
 
 
@@ -82,7 +82,7 @@ class M3u8(object):
                                      manifest_update=None):
         """ Updates an existing stream with parameters for the inputstream adaptive add-on.
 
-        :param strm:                    (MediaStream) the MediaStream to update
+        :param MediaStream strm:        The MediaStream to update
         :param dict headers:            Possible HTTP Headers
         :param str license_key:         The value of the license key request
         :param str license_type:        The type of license key request used (see below)
@@ -95,8 +95,7 @@ class M3u8(object):
 
         Can be used like this:
 
-            part = item.create_new_empty_media_part()
-            stream = part.append_media_stream(m3u8url, 0)
+            stream = item.add_stream(m3u8url, 0)
             M3u8.set_input_stream_addon_input(stream, self.headers)
             item.complete = True
 
@@ -145,16 +144,16 @@ class M3u8(object):
                                         key_value=key_value)
 
     @staticmethod
-    def update_part_with_m3u8_streams(part, url,
+    def update_part_with_m3u8_streams(item, url,
                                       encrypted=False,
                                       headers=None,
                                       map_audio=False,
                                       bitrate=0,
                                       channel=None):
-        """ Updates an existing MediaItemPart with M3u8 data either using the Adaptive Inputstream 
+        """ Updates an existing MediaItem with M3u8 data either using the Adaptive Inputstream
         Add-on or with the built-in code.
 
-        :param MediaItemPart part:      The part to update
+        :param MediaItem item:          The MediaItem to update
         :param str url:                 The url to download
         :param bool encrypted:          Is the stream encrypted?
         :param dict[str,str] headers:   Possible HTTP Headers
@@ -175,7 +174,7 @@ class M3u8(object):
 
         if input_stream:
             Logger.debug("Using InputStream Adaptive add-on for M3u8 playback.")
-            stream = part.append_media_stream(url, bitrate)
+            stream = item.add_stream(url, bitrate)
             M3u8.set_input_stream_addon_input(stream, headers)
             return True
 
@@ -187,12 +186,12 @@ class M3u8(object):
                     audio_part = a.rsplit("-", 1)[-1]
                     audio_part = "-%s" % (audio_part,)
                     s = s.replace(".m3u8", audio_part)
-                part.append_media_stream(s, b)
+                item.add_stream(s, b)
                 complete = True
         else:
             Logger.debug("Using Retrospect code for M3u8 playback.")
             for s, b in M3u8.get_streams_from_m3u8(url):
-                part.append_media_stream(s, b)
+                item.add_stream(s, b)
                 complete = True
 
         return complete
@@ -208,11 +207,10 @@ class M3u8(object):
 
         Can be used like this:
 
-            part = item.create_new_empty_media_part()
             for s, b in M3u8.get_streams_from_m3u8(m3u8_url):
                 item.complete = True
                 # s = self.get_verifiable_video_url(s)
-                part.append_media_stream(s, b)
+                item.add_stream(s, b)
 
         :param dict[str,str] headers:       Possible HTTP Headers
         :param str url:                     The url to download

--- a/resources/lib/streams/mpd.py
+++ b/resources/lib/streams/mpd.py
@@ -30,8 +30,7 @@ class Mpd(object):
 
         Can be used like this:
 
-            part = item.create_new_empty_media_part()
-            stream = part.append_media_stream(m3u8url, 0)
+            stream = item.add_stream(m3u8url, 0)
             M3u8.set_input_stream_addon_input(stream, self.headers)
             item.complete = True
 

--- a/resources/lib/streams/npostream.py
+++ b/resources/lib/streams/npostream.py
@@ -127,11 +127,10 @@ class NpoStream(object):
 
         Can be used like this:
 
-            part = item.create_new_empty_media_part()
             for s, b in NpoStream.get_streams_from_npo(m3u8Url):
                 item.complete = True
                 # s = self.get_verifiable_video_url(s)
-                part.append_media_stream(s, b)
+                item.add_stream(s, b)
 
         """
 

--- a/resources/lib/streams/npostream.py
+++ b/resources/lib/streams/npostream.py
@@ -7,6 +7,7 @@ from resources.lib.streams.mpd import Mpd
 from resources.lib.helpers.subtitlehelper import SubtitleHelper
 from resources.lib.urihandler import UriHandler
 from resources.lib.logger import Logger
+from resources.lib.mediaitem import MediaItem
 
 
 class NpoStream(object):
@@ -28,11 +29,12 @@ class NpoStream(object):
         return SubtitleHelper.download_subtitle(sub_title_url, stream_id + ".srt", format='srt')
 
     @staticmethod
-    def add_mpd_stream_from_npo(url, episode_id, part, headers=None, live=False):
+    def add_mpd_stream_from_npo(url, episode_id, item, headers=None, live=False):
         """ Extracts the Dash streams for the given url or episode id
 
         :param str|None url:        The url to download
         :param str episode_id:      The NPO episode ID
+        :param MediaItem item:      The Media item to update
         :param dict headers:        Possible HTTP Headers
         :param bool live:           Is this a live stream?
 
@@ -108,7 +110,7 @@ class NpoStream(object):
             license_key = None
 
         # Actually set the stream
-        stream = part.append_media_stream(stream_url, 0)
+        stream = item.add_stream(stream_url, 0)
         Mpd.set_input_stream_addon_input(stream,
                                          headers,
                                          license_key=license_key,

--- a/resources/lib/streams/youtube.py
+++ b/resources/lib/streams/youtube.py
@@ -57,11 +57,10 @@ class YouTube(object):
 
         Can be used like this:
 
-            part = item.create_new_empty_media_part()
             for s, b in YouTube.get_streams_from_you_tube(url):
                 item.complete = True
                 # s = self.get_verifiable_video_url(s)
-                part.append_media_stream(s, b)
+                item.add_stream(s, b)
 
         :return: a list of streams with their bitrate and optionally the audio streams.
         :rtype: list[tuple[str,str]]

--- a/tests/channel_tests/channeltest.py
+++ b/tests/channel_tests/channeltest.py
@@ -72,7 +72,7 @@ class ChannelTest(unittest.TestCase):
                 item.HttpHeaders.update(headers or {})
                 item = self.channel.process_video_item(item)
 
-                self.assertTrue(item.has_media_item_parts())
+                self.assertTrue(item.has_streams())
                 self.assertTrue(item.complete)
                 return item
             except:

--- a/tests/channel_tests/test_chn_kijknl.py
+++ b/tests/channel_tests/test_chn_kijknl.py
@@ -66,7 +66,7 @@ class TestKijkNlChannel(ChannelTest):
             }
         ]
         item = self.channel.process_video_item(item)
-        self.assertTrue(item.has_media_item_parts())
+        self.assertTrue(item.has_streams())
 
     def test_graphql_m3u8_video(self):
         item = self._get_media_item("https://graph.kijk.nl/graphql-video")
@@ -80,7 +80,7 @@ class TestKijkNlChannel(ChannelTest):
             }
         ]
         item = self.channel.process_video_item(item)
-        self.assertTrue(item.has_media_item_parts())
+        self.assertTrue(item.has_streams())
 
     def test_graphql_drm_video(self):
         item = self._get_media_item("https://graph.kijk.nl/graphql-video")
@@ -102,7 +102,7 @@ class TestKijkNlChannel(ChannelTest):
             }
         ]
         item = self.channel.process_video_item(item)
-        self.assertTrue(item.has_media_item_parts())
+        self.assertTrue(item.has_streams())
 
     def test_graphql_search(self):
         self._test_folder_url(

--- a/tests/channel_tests/test_chn_sbs.py
+++ b/tests/channel_tests/test_chn_sbs.py
@@ -307,7 +307,7 @@ class TestSbsSeChannel(ChannelTest):
         url = "https://disco-api.dplay.se/playback/videoPlaybackInfo/125461"
         item = self._get_media_item(url)
         item = self.channel.process_video_item(item)
-        self.assertTrue(item.has_media_item_parts())
+        self.assertTrue(item.has_streams())
 
     def test_item_premium_no_datelimit(self):
         result_set = json.loads('{"relationships":{"contentPackages":{"data":[{"type":"package","id":"Premium"}]}},"attributes":{"geoRestrictions":{"mode":"permit","countries":["world"]}}}')


### PR DESCRIPTION
### Functional description
<!--- Give a clear explanation of the change, fix or new feature 
that this PR contains -->
<!--- Put your text below this line -->
In the past a single item in Kodi could consist of multiple _parts_. Each part can then have multiple streams. This caused a lot of pain when playing items because playing a single item actually caused multiple items to be queued. 
<!--- Put your text above this line -->

### Reasoning
<!--- Provide a decent justification for this PR -->
<!--- Put your text below this line -->
In real life, almost no channels have multi-part streams. So the feature can be removed.
<!--- Put your text above this line -->

### Technical description
<!--- Please provide a technical analysis of this PR, explaining the 
 changes that were made. -->
<!--- Put your text below this line -->
Remove the `MediaItemPart` class and all related code and make the video playback a simple `xbmcplugin.setResolveUrl()`. 
<!--- Put your text above this line -->

### Tasks & Activities
<!-- What other tasks or activities need to be done to complete
this PR -->

- [x] Remove MediaPartItem
- [x] Update all channels to not use MediaItemParts anymore
- [x] Update docs in the code
- [x] Update tests.
