### PR TITLE
Annoying startup sound removal

### DIFF
--- a/resources/lib/plugin.py
+++ b/resources/lib/plugin.py
@@ -50,10 +50,6 @@ class Plugin(ActionParser):
             # print the folder structure
             env_ctrl.print_retrospect_settings_and_folders(Config, AddonSettings)
 
-            # show notification
-            XbmcWrapper.show_notification(None, LanguageHelper.get_localized_string(LanguageHelper.StartingAddonId) % (
-                Config.appName,), fallback=False, logger=Logger)
-
             # check for cache folder
             env_ctrl.cache_check()
 


### PR DESCRIPTION
This edit removes the annoying startup sound of retrospect.
It does not remove the "first run" startup sound after a addon update has been made.


