### PR TITLE
Showing NPO Start Extra items

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,4 +11,5 @@ _None_
 [B]Channel related[/B]
 * Fixed: NPO video playback broken (Fixes #1679).
 * Added: Tweede Kamer Debat Direct (Fixes #1394).
+* Added: List NPO Start Extra's and Fragmenten (Fixes #1649).
 

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -675,7 +675,19 @@ msgctxt "#30367"
 msgid "New on %s"
 msgstr ""
 
-# empty strings from id 30368 to 30400
+msgctxt "#30368"
+msgid "Extras"
+msgstr ""
+
+msgctxt "#30369"
+msgid "Fragments"
+msgstr ""
+
+msgctxt "#30370"
+msgid "All episodes"
+msgstr ""
+
+# empty strings from id 30371 to 30400
 
 msgctxt "#30401"
 msgid "Dutch"

--- a/resources/lib/helpers/languagehelper.py
+++ b/resources/lib/helpers/languagehelper.py
@@ -71,6 +71,9 @@ class LanguageHelper(object):
     Movies = 30365
     AvailableFrom = 30366
     NewOnChannel = 30367
+    Extras = 30368
+    Fragments = 30369
+    AllEpisodes = 30370
 
     ChannelSelection = 30507
     ShortCutName = 30512

--- a/tests/channel_tests/test_chn_nos2010.py
+++ b/tests/channel_tests/test_chn_nos2010.py
@@ -63,14 +63,64 @@ class TestNpoChannel(ChannelTest):
         self.assertGreaterEqual(len(folders), 0)
 
     def test_tv_show_listing_with_more_page_item(self):
+        # A show with multiple pages, but without extra items
         items = self._test_folder_url(
-            "https://start-api.npo.nl/media/series/NOSjnl2000/episodes?pageSize=10",
+            "https://start-api.npo.nl/media/series/NOSjnlMP/episodes?pageSize=10",
             headers={"apikey": "07896f1ee72645f68bc75581d7f00d54"},
             expected_results=101, exact_results=True
         )
         # More pages should be present (requested 5, will be more there)
         folders = [item for item in items if item.is_folder]
         self.assertGreaterEqual(len(folders), 1)
+
+    def test_tv_show_listing_with_extras(self):
+        # A show with extra items
+        items = self._test_folder_url(
+            "https://start-api.npo.nl/page/franchise/VPWON_1246712",
+            headers={"apikey": "07896f1ee72645f68bc75581d7f00d54"},
+            expected_results=23, exact_results=True
+        )
+        # There should be links to the full episode list (media/series/*/episodes),
+        # to the extras (media/series/*/clips), and to the fragments (media/series/*/fragments)
+        all_folders = [item for item in items if item.is_folder and "episodes" in item.url]
+        extras_folders = [item for item in items if item.is_folder and "clips" in item.url]
+        fragments_folders = [item for item in items if item.is_folder and "fragments" in item.url]
+        self.assertEqual(len(all_folders), 1)
+        self.assertEqual(len(extras_folders), 1)
+        self.assertEqual(len(fragments_folders), 1)
+
+    def test_tv_show_list_extras(self):
+        items = self._test_folder_url(
+            "https://start-api.npo.nl/media/series/KN_1678993/clips?pageSize=10",
+            headers={"apikey": "07896f1ee72645f68bc75581d7f00d54"},
+            expected_results=101, exact_results=True
+        )
+
+    def test_tv_show_list_fragments(self):
+        items = self._test_folder_url(
+            "https://start-api.npo.nl/media/series/POW_04596562/fragments?pageSize=10",
+            headers={"apikey": "07896f1ee72645f68bc75581d7f00d54"},
+            expected_results=100
+        )
+
+    def test_tv_show_listing_with_multiple_seasons(self):
+        # A show with multiple very short seasons
+        items = self._test_folder_url(
+            "https://start-api.npo.nl/page/franchise/NOS2016inBeeld",
+            headers={"apikey": "07896f1ee72645f68bc75581d7f00d54"},
+            expected_results=1
+        )
+        # There should be a link to the full episode list (media/series/*/episodes)
+        all_folders = [item for item in items if item.is_folder and "episodes" in item.url]
+        self.assertEqual(len(all_folders), 1)
+
+    def test_tv_show_listing_with_single_episode(self):
+        # A show with one episode, no seasons, should not have an "All episodes" folder
+        items = self._test_folder_url(
+            "https://start-api.npo.nl/page/franchise/POMS_S_NOS_349833",
+            headers={"apikey": "07896f1ee72645f68bc75581d7f00d54"},
+            expected_results=1, exact_results=True
+        )
 
     def test_guide_day_list(self):
         import datetime


### PR DESCRIPTION
### Functional description
<!--- Give a clear explanation of the change, fix or new feature 
that this PR contains -->
<!--- Put your text below this line -->
This adds the "Extra" items for the shows in the NPO Start channel, as listed on the [NPO Start website](https://www.npostart.nl/) and in the app.
<!--- Put your text above this line -->

### Reasoning
<!--- Provide a decent justification for this PR -->
<!--- Put your text below this line -->
Some shows have additional online-only content. See also #1649.
<!--- Put your text above this line -->

### Technical description
<!--- Please provide a technical analysis of this PR, explaining the 
 changes that were made. -->
<!--- Put your text below this line -->
This change adds an "Extra" folder to the episode list for shows that have extra content. These clips are then loaded using the NPO Start API and can be browsed and viewed using the existing codebase.

As an alternative to having them in a separate folder, the Extra clips could be added to the list of episodes with an "Extra:" prefix. This makes the pagination more complicated for shows with many episodes. I would also argue that the extra content is different from the main episodes, so it makes sense to separate them.
<!--- Put your text above this line -->

### Tasks & Activities
<!-- What other tasks or activities need to be done to complete
this PR -->

- [ ] Decide on the best way to show these clips.
- [ ] Review the changes.