### PR TITLE
Fixed: Tweede Kamer date parsing in Python 2.7

### DIFF
--- a/channels/channel.videos/tweedekamer/chn_tweedekamer.py
+++ b/channels/channel.videos/tweedekamer/chn_tweedekamer.py
@@ -339,8 +339,9 @@ class Channel(chn_class.Channel):
         # create a MediaItem for the debate, given the JSON metadata 
 
         # startsAt is the official starting time in the calendar
-        time_stamp = DateHelper.get_date_from_string(debate["startsAt"],
-                                                     date_format="%Y-%m-%dT%H:%M:%S%z")
+        # we ignore the time zone to always use the local Dutch time
+        time_stamp = DateHelper.get_date_from_string(debate["startsAt"][:19],
+                                                     date_format="%Y-%m-%dT%H:%M:%S")
 
         url = "https://cdn.debatdirect.tweedekamer.nl/api/agenda/%s/debates/%s" \
                 % (debate["debateDate"], debate["id"])


### PR DESCRIPTION
Fix for pull request #1678, which introduced a time zone parsing bug in Python 2.7.

The Tweede Kamer channel included the time zone when parsing the date and time of videos. This worked in Python 3, where `strptime` supports formats with `%z`, but not in Python 2.7. This fix removes the time zone from the date-time string. This means the interface will always use the local Dutch time for the debates, which should be fine.