### PR TITLE
Fixed: Some Radio 538 Video streams did not play (Fixes #1685)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,4 +12,4 @@ _None_
 * Fixed: NPO video playback broken (Fixes #1679).
 * Added: Tweede Kamer Debat Direct (Fixes #1394).
 * Added: List NPO Start Extra's and Fragmenten (Fixes #1649).
-
+* Fixed: Some Radio 538 Video streams did not play (Fixes #1685)

--- a/channels/channel.streams/radio538/chn_radio538.py
+++ b/channels/channel.streams/radio538/chn_radio538.py
@@ -61,7 +61,7 @@ class Channel(chn_class.Channel):
                                 "https://hls.slam.nl/streaming/hls/"],
                                updater=self.update_live_stream_m3u8)
 
-        self._add_data_parser(r"https://radio538-nl.+\.m3u8", match_type=ParserData.MatchRegex,
+        self._add_data_parser(r"https://radio538(-nl)?.+\.m3u8", match_type=ParserData.MatchRegex,
                               updater=self.update_live_stream_m3u8)
 
         self._add_data_parser("https://playerservices.streamtheworld.com/api/livestream-redirect",
@@ -448,10 +448,7 @@ class Channel(chn_class.Channel):
 
         """
 
-        for s, b in M3u8.get_streams_from_m3u8(item.url):
-            item.complete = True
-            item.add_stream(s, b)
-
+        M3u8.update_part_with_m3u8_streams(item, item.url, channel=self, encrypted=False)
         item.complete = True
         return item
 


### PR DESCRIPTION
### Functional description
<!--- Give a clear explanation of the change, fix or new feature 
that this PR contains -->
<!--- Put your text below this line -->
Radio 538 broke due to a parser issue.
<!--- Put your text above this line -->
