### PR TITLE
Fixed: NRK occasionally using timestamps with sub-second precision

### DIFF
--- a/channels/channel.no/nrkno/chn_nrkno.py
+++ b/channels/channel.no/nrkno/chn_nrkno.py
@@ -537,7 +537,7 @@ class Channel(chn_class.Channel):
         elif "usageRights" in result_set and "from" in result_set["usageRights"] and result_set["usageRights"]["from"] is not None:
             Logger.trace("Using 'usageRights.from.date' for date")
             # noinspection PyTypeChecker
-            date_value = result_set["usageRights"]["from"]["date"].split("+")[0]
+            date_value = result_set["usageRights"]["from"]["date"].split("+")[0].split(".")[0]
             time_stamp = DateHelper.get_date_from_string(date_value, date_format="%Y-%m-%dT%H:%M:%S")
             item.set_date(*time_stamp[0:6])
 


### PR DESCRIPTION
### Functional description
<!--- Give a clear explanation of the change, fix or new feature 
that this PR contains -->
<!--- Put your text below this line -->
Occasionally NRK uses timestamps with sub-second precision, leading to an exception when trying to parse them.
<!--- Put your text above this line -->

### Reasoning
<!--- Provide a decent justification for this PR -->
<!--- Put your text below this line -->
This PR enables handling of the previously unexpected timestamps and thus listing/playing of the respective shows
<!--- Put your text above this line -->

### Technical description
<!--- Please provide a technical analysis of this PR, explaining the 
 changes that were made. -->
<!--- Put your text below this line -->
Truncate timestamps that don't follow the expected format, i.e. truncate everything behind the "." in timestamps with the following format: "%Y-%m-%dT%H:%M:%S.%f"
<!--- Put your text above this line -->