### PR TITLE
Feature nrk add headliner

### DIFF
--- a/channels/channel.no/nrkno/chn_nrkno.py
+++ b/channels/channel.no/nrkno/chn_nrkno.py
@@ -167,8 +167,8 @@ class Channel(chn_class.Channel):
         links = {
             live_tv: "https://psapi.nrk.no/tv/live?apiKey={}".format(self.__api_key),
             live_radio: "https://psapi.nrk.no/radio/live?apiKey={}".format(self.__api_key),
-            "Headliner": "https://psapi.nrk.no/tv/headliners/default?apiKey={}".format(self.__api_key),
-            "Recommended": "https://psapi.nrk.no/medium/tv/recommendedprograms?maxnumber=100&startRow=0&apiKey={}".format(self.__api_key),
+            "Recommended": "https://psapi.nrk.no/tv/headliners/default?apiKey={}".format(self.__api_key),
+            #"Recommended": "https://psapi.nrk.no/medium/tv/recommendedprograms?maxnumber=100&startRow=0&apiKey={}".format(self.__api_key),
             "Popular": "https://psapi.nrk.no/medium/tv/popularprograms/week?maxnumber=100&startRow=0&apiKey={}".format(self.__api_key),
             "Recent": "https://psapi.nrk.no/medium/tv/recentlysentprograms?maxnumber=100&startRow=0&apiKey={}".format(self.__api_key),
             "Categories": "http://psapi-granitt-prod-we.cloudapp.net/medium/tv/categories?apiKey={}".format(self.__api_key),

--- a/resources/lib/connectivity/cachehttpadapter.py
+++ b/resources/lib/connectivity/cachehttpadapter.py
@@ -122,6 +122,8 @@ class CacheHTTPAdapter(HTTPAdapter):
 
         if "cache-control" in headers:
             cache_control = headers['cache-control']
+            #The "Headliner" NRK API endpoint uses ';' instead of ',' as a field delimiter
+            cache_control = cache_control.replace(";", ",")
             for entry in cache_control.strip().split(","):
                 if entry.find("=") > 0:
                     (key, value) = entry.split("=")

--- a/resources/lib/connectivity/cachehttpadapter.py
+++ b/resources/lib/connectivity/cachehttpadapter.py
@@ -122,7 +122,7 @@ class CacheHTTPAdapter(HTTPAdapter):
 
         if "cache-control" in headers:
             cache_control = headers['cache-control']
-            #The "Headliner" NRK API endpoint uses ';' instead of ',' as a field delimiter
+            #Some responses contain ';' as a delimiter. Fixing that.
             cache_control = cache_control.replace(";", ",")
             for entry in cache_control.strip().split(","):
                 if entry.find("=") > 0:

--- a/tests/channel_tests/test_chn_nrkno.py
+++ b/tests/channel_tests/test_chn_nrkno.py
@@ -14,7 +14,7 @@ class TestNrkNoChannel(ChannelTest):
 
     def test_main_list(self):
         items = self.channel.process_folder_list(None)
-        self.assertEqual(len(items), 8, "No items found in mainlist")
+        self.assertEqual(len(items), 9, "No items found in mainlist")
 
     def test_abcxyz(self):
         url = "https://psapi.nrk.no/medium/tv/letters?apiKey=d1381d92278a47c09066460f2522a67d"
@@ -46,6 +46,10 @@ class TestNrkNoChannel(ChannelTest):
 
     def test_list_liv_tv(self):
         url = "https://psapi.nrk.no/tv/live?apiKey=d1381d92278a47c09066460f2522a67d"
+        self._test_folder_url(url, expected_results=2)
+
+    def test_headliner(self):
+        url = "https://psapi.nrk.no/tv/headliners/default?apiKey=d1381d92278a47c09066460f2522a67d"
         self._test_folder_url(url, expected_results=2)
 
     @unittest.skip("No longer available in the new API.")

--- a/tests/channel_tests/test_chn_nrkno.py
+++ b/tests/channel_tests/test_chn_nrkno.py
@@ -14,7 +14,7 @@ class TestNrkNoChannel(ChannelTest):
 
     def test_main_list(self):
         items = self.channel.process_folder_list(None)
-        self.assertEqual(len(items), 9, "No items found in mainlist")
+        self.assertEqual(len(items), 8, "No items found in mainlist")
 
     def test_abcxyz(self):
         url = "https://psapi.nrk.no/medium/tv/letters?apiKey=d1381d92278a47c09066460f2522a67d"


### PR DESCRIPTION
### Functional description
<!--- Give a clear explanation of the change, fix or new feature 
that this PR contains -->
<!--- Put your text below this line -->
Substitute dysfunctional Recommended API by "Headliners" API endpoint, which provides a short list of recommended programs, typically what one would see highlighted very prominently on the website or app.
<!--- Put your text above this line -->

### Reasoning
<!--- Provide a decent justification for this PR -->
<!--- Put your text below this line -->
Recommendations have been broken for quite a while and the new API solves the same function of giving a short list of recommendations
<!--- Put your text above this line -->

### Technical description
<!--- Please provide a technical analysis of this PR, explaining the 
 changes that were made. -->
<!--- Put your text below this line -->
Parses output from the "Headliner" API-endpoint, which is structured differently then the rest of NRKs catalogue and creates a list of entries pointing to Series or directly to Videos.
Apparently this API is served by "something" different than the other APIs as the HTTP header is slightly malformatted. Instead of "," the cache-control directives are separated by ";", which needs a little workaround in cachehttpadater.
<!--- Put your text above this line -->

