### PR TITLE
Postprocess videoland episodes

### DIFF
--- a/channels/channel.videoland/videolandnl/chn_videolandnl.py
+++ b/channels/channel.videoland/videolandnl/chn_videolandnl.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import datetime
+import re
 from typing import Union, List, Optional, Tuple, Dict
 
 import pytz
@@ -55,6 +56,7 @@ class Channel(chn_class.Channel):
             match_type=ParserData.MatchRegex,
             name="Main processor that create content items (folders/videos) from blocks",
             json=True, requires_logon=True,
+            postprocessor=self.postprocess_episodes,
             parser=["content", "items"], creator=self.create_content_item)
 
         self._add_data_parser(
@@ -254,6 +256,34 @@ class Channel(chn_class.Channel):
         json_data = JsonHelper(data)
         self.__program_id = json_data.get_value("entity", "id", fallback=None)
         return json_data, []
+
+    def postprocess_episodes(self, data, items: list[MediaItem]) -> list[MediaItem]:        
+        # Season episodes can be named ["Aflevering 1", "Aflevering 2"] and so on, or ["Some episode name", "Another episode name", "Yet another episode name"]
+        # without an episode number. Some episodes have a date, and some have no date, even within a single season.
+
+        # All this messes up Kodi episode ordering by either date or name:
+        # If no episodes have a date, Kodi orders by name, so "Another episode name" becomes the first episode instead of the second.
+        # If some episodes have a date and some later ones don't, Kodi shows the later ones as the first episodes (mindate), followed by the ones with a date.
+
+        # This postprocessing function fixes name ordering by adding an episode number in front of the title if the episodes
+        # are not like "Aflevering 1", "Aflevering 2" and so on.
+        # Episode names become ["01 Some episode name", "02 Another episode name", "03 Yet another episode name"].
+        # Numbered episodes are fairly common, and in this case it is useful to achieve the right sort order by name.
+
+        # This postprocessing function fixes date ordering by setting the date of an episode, if it has no date, to the date of the previous episode.
+        if (len(items) > 1
+            and data.json.get("featureId") == "videos_by_season_by_program"
+            and all(item.media_type == "episode" and not re.match("[Aa]flevering \d+", item.name) for item in items)):
+            date = ""
+            for index, item in enumerate(items, start=1):
+                item.name = f"{index:02} {item.name}"
+                if (not item.has_date() and date):
+                    timestamp = datetime.datetime.strptime(date, "%Y-%m-%d")
+                    item.set_date(timestamp.year, timestamp.month, timestamp.day)
+                else:
+                    date = item.get_date()
+
+        return items
 
     def create_program_item(self, result_set: dict) -> Union[MediaItem, List[MediaItem], None]:
         if not result_set["title"]:

--- a/tests/channel_tests/test_chn_videoland.py
+++ b/tests/channel_tests/test_chn_videoland.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+import datetime
+from . channeltest import ChannelTest
+
+class TestVideolandNLChannel(ChannelTest):
+    class JsonWrapper:
+        def __init__(self, data):
+            self.json = data
+
+    # noinspection PyPep8Naming
+    def __init__(self, methodName):  # NOSONAR
+        super(TestVideolandNLChannel, self).__init__(methodName, "channel.videoland.videolandnl", None)
+
+    def test_channel_exists(self):
+        self.assertIsNotNone(self.channel)
+
+    def test_episode_number_added_for_season(self):
+        data = self.JsonWrapper({ "featureId": "videos_by_season_by_program" })
+        items = [
+            self.create_media_item("Some episode name"),
+            self.create_media_item("Another episode name"),
+            self.create_media_item("Yet another episode name"),
+        ]
+
+        changed = self.channel.postprocess_episodes(data, items)
+        self.assertCountEqual(changed, items)
+        self.assertEqual(changed[0].name, "01 Some episode name")
+        self.assertEqual(changed[1].name, "02 Another episode name")
+        self.assertEqual(changed[2].name, "03 Yet another episode name")
+
+    def test_episode_number_not_added_for_other_than_episode(self):
+        data = self.JsonWrapper({ "featureId": "videos_by_season_by_program" })
+        items = [
+            self.create_media_item("Some episode name","no_episode"),
+            self.create_media_item("Another episode name","no_episode"),
+            self.create_media_item("Yet another episode name","no_episode"),
+        ]
+
+        changed = self.channel.postprocess_episodes(data, items)
+        self.assertCountEqual(changed, items)
+        self.assertEqual(changed[0].name, "Some episode name")
+        self.assertEqual(changed[1].name, "Another episode name")
+        self.assertEqual(changed[2].name, "Yet another episode name")
+
+    def test_episode_number_not_added_for_other_list(self):
+        data = self.JsonWrapper({ "featureId": "other" })
+        items = [
+            self.create_media_item("Some episode name"),
+            self.create_media_item("Another episode name"),
+            self.create_media_item("Yet another episode name"),
+        ]
+
+        changed = self.channel.postprocess_episodes(data, items)
+        self.assertCountEqual(changed, items)
+        self.assertEqual(changed[0].name, "Some episode name")
+        self.assertEqual(changed[1].name, "Another episode name")
+        self.assertEqual(changed[2].name, "Yet another episode name")
+
+    def test_episode_number_not_added_for_aflevering(self):
+        data = self.JsonWrapper({ "featureId": "videos_by_season_by_program" })
+        # Aflevering ordered backwards
+        items = [
+            self.create_media_item("Aflevering 3"),
+            self.create_media_item("Aflevering 2"),
+            self.create_media_item("Aflevering 1"),
+        ]
+
+        changed = self.channel.postprocess_episodes(data, items)
+        self.assertCountEqual(changed, items)
+        self.assertEqual(changed[0].name, "Aflevering 3")
+        self.assertEqual(changed[1].name, "Aflevering 2")
+        self.assertEqual(changed[2].name, "Aflevering 1")
+
+    def test_episode_number_date_filled_in(self):
+        data = self.JsonWrapper({ "featureId": "videos_by_season_by_program" })
+        items = [
+            self.create_media_item("Some episode name", date="2022-07-05"),
+            self.create_media_item("Another episode name", date="2022-07-06"),
+            self.create_media_item("Yet another episode name")
+        ]
+
+        changed = self.channel.postprocess_episodes(data, items)
+        self.assertCountEqual(changed, items)
+        self.assertEqual(changed[0].name, "01 Some episode name")
+        self.assertEqual(changed[1].name, "02 Another episode name")
+        self.assertEqual(changed[2].name, "03 Yet another episode name")
+        self.assertTrue(changed[0].has_date())
+        self.assertTrue(changed[1].has_date())
+        self.assertTrue(changed[2].has_date())
+        self.assertEqual(changed[0].get_date(), "2022-07-05")
+        self.assertEqual(changed[1].get_date(), "2022-07-06")
+        self.assertEqual(changed[2].get_date(), "2022-07-06")
+
+    def create_media_item(self, name, media_type = "episode", date = ""):
+        item = self._get_media_item("", name)
+        item.media_type = media_type
+        if (date):
+            timestamp = datetime.datetime.strptime(date, "%Y-%m-%d")
+            item.set_date(timestamp.year, timestamp.month, timestamp.day)
+        return item

--- a/tests/channel_tests/test_chn_videoland.py
+++ b/tests/channel_tests/test_chn_videoland.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import datetime
+
+from resources.lib.helpers.datehelper import DateHelper
 from . channeltest import ChannelTest
 
 class TestVideolandNLChannel(ChannelTest):
@@ -83,7 +85,7 @@ class TestVideolandNLChannel(ChannelTest):
         self.assertCountEqual(changed, items)
         self.assertEqual(changed[0].name, "01 Some episode name")
         self.assertEqual(changed[1].name, "02 Another episode name")
-        self.assertEqual(changed[2].name, "03 Yet another episode name")
+        self.assertEqual(changed[2].name, "03 Yet another episode name [date unknown]")
         self.assertTrue(changed[0].has_date())
         self.assertTrue(changed[1].has_date())
         self.assertTrue(changed[2].has_date())
@@ -95,6 +97,6 @@ class TestVideolandNLChannel(ChannelTest):
         item = self._get_media_item("", name)
         item.media_type = media_type
         if (date):
-            timestamp = datetime.datetime.strptime(date, "%Y-%m-%d")
+            timestamp = DateHelper.get_datetime_from_string(date, "%Y-%m-%d")
             item.set_date(timestamp.year, timestamp.month, timestamp.day)
         return item


### PR DESCRIPTION
### Functional description
<!--- Give a clear explanation of the change, fix or new feature 
that this PR contains -->
<!--- Put your text below this line -->
Season episodes can be named ["Aflevering 1", "Aflevering 2"] and so on, or ["Some episode name", "Another episode name", "Yet another episode name"]
without an episode number. Some episodes have a date, and some have no date, even within a single season.

All this messes up Kodi episode ordering by either date or name:
If no episodes have a date, Kodi orders by name, so "Another episode name" becomes the first episode instead of the second.
If some episodes have a date and some later ones don't, Kodi shows the later ones as the first episodes (mindate), followed by the ones with a date.
<!--- Put your text above this line -->

### Reasoning
<!--- Provide a decent justification for this PR -->
<!--- Put your text below this line -->
This PR fixes the Videoland episode order.
<!--- Put your text above this line -->

### Technical description
<!--- Please provide a technical analysis of this PR, explaining the 
 changes that were made. -->
<!--- Put your text below this line -->
This postprocessing function fixes name ordering by adding an episode number in front of the title if the episodes
are not like "Aflevering 1", "Aflevering 2" and so on.
Episode names become ["01 Some episode name", "02 Another episode name", "03 Yet another episode name"].
Numbered episodes are fairly common, and in this case it is useful to achieve the right sort order by name.

This postprocessing function fixes date ordering by setting the date of an episode, if it has no date, to the date of the previous episode.
<!--- Put your text above this line -->

### Tasks & Activities
<!-- What other tasks or activities need to be done to complete
this PR -->
