### PR TITLE
Fixed: item 'ondek meer genres' missing in NPO's 'TV shows'

### DIFF
--- a/channels/channel.nos/nos2010/chn_nos2010.py
+++ b/channels/channel.nos/nos2010/chn_nos2010.py
@@ -151,6 +151,10 @@ class Channel(chn_class.Channel):
                               name="Bare pages layout", json=True,
                               parser=["collections"], creator=self.create_api_page_layout)
 
+        self._add_data_parser("https://npo.nl/start/api/domain/page-collection?type=dynamic_page&guid=",
+                              name="Categories layout", json=True,
+                              parser=["items"], creator=self.create_api_category_item)
+
         # Favourites (not yet implemented in the site).
         self._add_data_parser("https://npo.nl/start/api/domain/user-profiles",
                               match_type=ParserData.MatchExact, json=True,
@@ -593,6 +597,8 @@ class Channel(chn_class.Channel):
             content_type = contenttype.TVSHOWS
         elif page_type == "PROGRAM":
             content_type = contenttype.EPISODES
+        elif page_type == "DYNAMIC_PAGE":
+            content_type = contenttype.VIDEOS
         else:
             Logger.error(f"Missing for page type: {page_type}")
             return None

--- a/tests/channel_tests/test_chn_nos2010.py
+++ b/tests/channel_tests/test_chn_nos2010.py
@@ -114,6 +114,9 @@ class TestNpoChannel(ChannelTest):
     def test_programs(self):
         self._test_folder_url("https://npo.nl/start/api/domain/page-layout?slug=programmas", 5)
 
+    def test_more_genres(self):
+        self._test_folder_url("https://npo.nl/start/api/domain/page-collection?type=dynamic_page&guid=2670b702-d621-44be-b411-7aae3c3820eb", 9)
+
     def test_page(self):
         self._test_folder_url("https://npo.nl/start/api/domain/page-collection?type=series&guid=cc065da7-e6d2-44d6-bbce-2d600954e0b0", 10)
 


### PR DESCRIPTION
### Functional description
<!--- Give a clear explanation of the change, fix or new feature 
that this PR contains -->
<!--- Put your text below this line -->
Adds an entry 'ondek meer genres' to the genres currently display in menu NPO -> 'TV Shows', allowing acces to more catergories and sub-categories, and ultimately a lot of additional programmes.
<!--- Put your text above this line -->

### Reasoning
<!--- Provide a decent justification for this PR -->
<!--- Put your text below this line -->
This entry, althought present on NPO's website, was missing in the channel's menu. Without it, a large number of programmes would only be available by doing a search.
<!--- Put your text above this line -->

### Technical description
<!--- Please provide a technical analysis of this PR, explaining the 
 changes that were made. -->
<!--- Put your text below this line -->
Allowed an extra page_type `DYNAMIC_PAGE` and used an already exisiting (but unused?) parser to parse these pages.
<!--- Put your text above this line -->

### Tasks & Activities
<!-- What other tasks or activities need to be done to complete
this PR -->
Don't think so. To me at least, it works quite satisfactory.
