### PR TITLE
Fixed: Parsing of WebVTT subtitles which contain text after the WEBVTT keyword

### DIFF
--- a/resources/lib/helpers/subtitlehelper.py
+++ b/resources/lib/helpers/subtitlehelper.py
@@ -260,7 +260,7 @@ class SubtitleHelper(object):
         result = ""
         for line in webvvt.split("\n"):
             line = line.strip()
-            if line.endswith("WEBVTT") or line.startswith("X-TIMESTAMP"):
+            if line.startswith("WEBVTT") or line.startswith("X-TIMESTAMP"):
                 continue
             if not line:
                 continue


### PR DESCRIPTION
### Functional description
<!--- Give a clear explanation of the change, fix or new feature 
that this PR contains -->
<!--- Put your text below this line -->
Fixing helper that converts WebVTT to SRT subtitle format for WebVTT files with a slightly uncommon format.
<!--- Put your text above this line -->

### Reasoning
<!--- Provide a decent justification for this PR -->
<!--- Put your text below this line -->
NRK was consistently using a format that the parser didn't handle appropriately, which broke most, if not all subtitles on NRK.
<!--- Put your text above this line -->

### Technical description
<!--- Please provide a technical analysis of this PR, explaining the 
 changes that were made. -->
<!--- Put your text below this line -->
According to https://www.w3.org/TR/webvtt1/#webvtt-file-body the WebVTT format allows arbitrary text after the "WEBVTT" keyword. With the previous parser implementation those lines where not ignored like they should.
<!--- Put your text above this line -->
