### PR TITLE
Fixed: NPO TV programmes.

### DIFF
--- a/tests/channel_tests/test_chn_nos2010.py
+++ b/tests/channel_tests/test_chn_nos2010.py
@@ -110,14 +110,19 @@ class TestNpoChannel(ChannelTest):
         self._test_folder_url(url, 5)
 
     def test_programs(self):
-        self._test_folder_url("https://npo.nl/start/api/domain/page-layout?layoutId=programmas&layoutType=PAGE", 5)
+        url = "https://npo.nl/start/api/domain/page-layout?layoutId=programmas&layoutType=PAGE&includePremiumContent=true&partyId=1"
+        self._test_folder_url(url, 5)
 
     @unittest.skip("No longer used")
     def test_more_genres(self):
-        self._test_folder_url("https://npo.nl/start/api/domain/page-collection?type=dynamic_page&collectionId=118e43f3-864a-4dbd-91ea-c6450a8d2c25&partyId=1&layoutType=PAGE", 7)
+        # TV shows/Genres
+        url = "https://npo.nl/start/api/domain/page-collection?collectionType=PAGE&collectionId=5817f2c3-dd7f-4c68-9c46-8fe2e630f85f&partyId=1&layoutType=PAGE&includePremiumContent=true"
+        self._test_folder_url(url, 5)
 
     def test_page(self):
-        self._test_folder_url("https://npo.nl/start/api/domain/page-collection?type=series&collectionId=db612122-75e0-4f6c-8a32-e9202ae9fce8&partyId=1&layoutType=PAGE", 10)
+        # TV shows/Nieuws en actualiteiten
+        url = "https://npo.nl/start/api/domain/page-collection?collectionType=SERIES&collectionId=cab647cf-7bf6-4c7c-9610-cb9e46dbfdde&partyId=1&layoutType=PAGE&includePremiumContent=true"
+        self._test_folder_url(url, 10)
 
     def test_update_stream_pow(self):
         url = "KN_1693383"


### PR DESCRIPTION
### Functional description
<!--- Give a clear explanation of the change, fix or new feature 
that this PR contains -->
<!--- Put your text below this line -->
Fixes NPO -> TV shows has no items
<!--- Put your text above this line -->

### Reasoning
<!--- Provide a decent justification for this PR -->
<!--- Put your text below this line -->

<!--- Put your text above this line -->

### Technical description
<!--- Please provide a technical analysis of this PR, explaining the 
 changes that were made. -->
<!--- Put your text below this line -->
 Requests to this page and child folders returned HTTP status 400, due to some changes in the query string.
- paramater `type` is now named `collectionType`
- `collectionType`  value is now in uppercase, because that's what the website does.
- extra manditory paramater `includePremiumContent`

The value of `includePremiumContent` respects add-on setting `hide_premium_items`, but at first glance it doesn't seem to make much difference.

<!--- Put your text above this line -->

### Tasks & Activities
<!-- What other tasks or activities need to be done to complete
this PR -->

- [ ] Activity 1
- [ ] Activity 2
