### PR TITLE
Fixed: NPO KeyError crash for unknown live channels

### DIFF
--- a/channels/channel.nos/nos2010/chn_nos2010.py
+++ b/channels/channel.nos/nos2010/chn_nos2010.py
@@ -1346,7 +1346,7 @@ class Channel(chn_class.Channel):
             iptv_streams.append(dict(
                 id=JsonHelper.get_from(livestream, "guid"),
                 name=JsonHelper.get_from(livestream, "title"),
-                logo=logo_sources[JsonHelper.get_from(livestream, "title")],
+                logo=logo_sources.get(JsonHelper.get_from(livestream, "title"), ""),
                 group=self.channelName,
                 stream=parameter_parser.create_action_url(self, action=action.PLAY_VIDEO, item=item,
                                                           store_id=parent_item.guid),


### PR DESCRIPTION
### Functional description
<!--- Give a clear explanation of the change, fix or new feature 
that this PR contains -->
<!--- Put your text below this line -->
NPO was producing some errors in the logs, this tries to fix them.
<!--- Put your text above this line -->

### Reasoning
<!--- Provide a decent justification for this PR -->
<!--- Put your text below this line -->
Less errors is better ;)
<!--- Put your text above this line -->

### Technical description
<!--- Please provide a technical analysis of this PR, explaining the 
 changes that were made. -->
<!--- Put your text below this line -->
The NPO guide-channels API now returns regional channels like 'RTV Noord' that aren't in the logo_sources dict. Use .get() with empty string fallback instead of direct dict access.
<!--- Put your text above this line -->

### Tasks & Activities
<!-- What other tasks or activities need to be done to complete
this PR -->

none
