### PR TITLE
Added: Add genre, description, subtitle to NOS IPTV EPG

### DIFF
--- a/channels/channel.nos/nos2010/chn_nos2010.py
+++ b/channels/channel.nos/nos2010/chn_nos2010.py
@@ -1392,6 +1392,14 @@ class Channel(chn_class.Channel):
                     if len(JsonHelper.get_from(item, "images")) > 0:
                         iptv_epg_item["image"] = JsonHelper.get_from(item, "images")[0].get("url")
 
+                    genres = item.get("genres") or []
+                    if genres:
+                        iptv_epg_item["genre"] = genres[0].get("name", "")
+                    if item.get("synopsis"):
+                        iptv_epg_item["description"] = item["synopsis"]
+                    if item.get("episodeTitle"):
+                        iptv_epg_item["subtitle"] = item["episodeTitle"]
+
                     if media_item is not None:
                         iptv_epg_item["stream"] = parameter_parser.create_action_url(
                             self, action=action.PLAY_VIDEO, item=media_item, store_id=parent.guid)


### PR DESCRIPTION
### Functional description
<!--- Give a clear explanation of the change, fix or new feature 
that this PR contains -->
<!--- Put your text below this line -->
EPG was not showing descriptions and genre's.
<!--- Put your text above this line -->

### Reasoning
<!--- Provide a decent justification for this PR -->
<!--- Put your text below this line -->
Make EPG descriptions and Genre's work for NOS
<!--- Put your text above this line -->

### Technical description
<!--- Please provide a technical analysis of this PR, explaining the 
 changes that were made. -->
<!--- Put your text below this line -->
The guide-channel API already returns genres[0].name (Dutch), synopsis, and episodeTitle for every program but they were silently discarded when building the JSON-EPG item dict.
<!--- Put your text above this line -->

### Tasks & Activities
<!-- What other tasks or activities need to be done to complete
this PR -->

- [ ] Needs some further testing
- [x] Closes https://github.com/retrospect-addon/plugin.video.retrospect/pull/1756