### PR TITLE
Fixed: Logger shutdown safety during Python cleanup

### DIFF
--- a/resources/lib/logger.py
+++ b/resources/lib/logger.py
@@ -136,6 +136,8 @@ class Logger:
         """
 
         # noinspection PyArgumentList
+        if Logger.__logger is None:
+            return
         Logger.__logger.__write(msg, level=Logger.LVL_TRACE, *args, **kwargs)
         return
 
@@ -153,6 +155,8 @@ class Logger:
         """
 
         # noinspection PyArgumentList
+        if Logger.__logger is None:
+            return
         Logger.__logger.__write(msg, level=Logger.LVL_DEBUG, *args, **kwargs)
         return
 
@@ -170,6 +174,8 @@ class Logger:
         """
 
         # noinspection PyArgumentList
+        if Logger.__logger is None:
+            return
         Logger.__logger.__write(msg, level=Logger.LVL_INFO, *args, **kwargs)
         return
 
@@ -187,6 +193,8 @@ class Logger:
         """
 
         # noinspection PyArgumentList
+        if Logger.__logger is None:
+            return
         Logger.__logger.__write(msg, level=Logger.LVL_ERROR, *args, **kwargs)
         return
 
@@ -204,6 +212,8 @@ class Logger:
         """
 
         # noinspection PyArgumentList
+        if Logger.__logger is None:
+            return
         Logger.__logger.__write(msg, level=Logger.LVL_WARNING, *args, **kwargs)
         return
 
@@ -221,6 +231,8 @@ class Logger:
         """
 
         # noinspection PyArgumentList
+        if Logger.__logger is None:
+            return
         Logger.__logger.__write(msg, level=Logger.LVL_CRITICAL, *args, **kwargs)
         return
 


### PR DESCRIPTION
After Logger.instance().close_log(log_closing=True) sets the singleton to None, any subsequent Logger.debug/info/warning/error/critical/trace call raises:

  AttributeError: 'NoneType' object has no attribute '_Logger__write'

This surfaces in `__del__` destructors (KodiSettings, LocalSettings, Cloaker) that run after the logger is torn down during Python interpreter shutdown. The destructor calls are "Exception ignored in:" — normally suppressed at exit but visible with -W error or in test harnesses.

Fix: add a `if Logger.__logger is None: return` guard at the top of every static log method so post-shutdown calls silently no-op.