### PR TITLE
Fixed: Return early and navigate back when mainlist login fails

### DIFF
--- a/resources/lib/actions/folderaction.py
+++ b/resources/lib/actions/folderaction.py
@@ -63,6 +63,11 @@ class FolderAction(AddonAction):
                 watcher = StopWatch("Plugin process_folder_list With Items", Logger.instance())
                 media_items = self.__favorites
 
+            if media_items is None:
+                Logger.warning("process_folder_list returned None, navigating back")
+                xbmcplugin.endOfDirectory(self.handle, False)
+                return
+
             if len(media_items) == 0:
                 Logger.warning("process_folder_list returned %s items", len(media_items))
                 ok = self.__show_empty_information(media_items, favs=self.__favorites is not None)

--- a/resources/lib/chn_class.py
+++ b/resources/lib/chn_class.py
@@ -201,6 +201,15 @@ class Channel:
         if [p for p in data_parsers if p.LogOnRequired]:
             Logger.info("One or more dataparsers require logging in.")
             self.loggedOn = self.log_on()
+            if not self.loggedOn:
+                Logger.warning("Could not log on for: %s", self)
+                title = LanguageHelper.get_localized_string(LanguageHelper.LoginErrorTitle)
+                text = LanguageHelper.get_localized_string(LanguageHelper.LoginErrorText)
+                XbmcWrapper.show_notification(
+                    title, text, display_time=2000,
+                    notification_type=XbmcWrapper.Error,
+                    logger=Logger.instance())
+                return None
 
         # now set the headers here and not earlier in case they might have been update by the logon
         if parent_item is not None and parent_item.HttpHeaders:


### PR DESCRIPTION
When a channel's main list requires login and log_on() fails (e.g. user cancels device auth), return None from process_folder_list instead of an empty list. FolderAction detects the None sentinel and calls endOfDirectory(handle, False), causing Kodi to navigate back to the channel overview.

A brief login-error notification is shown (matching the sub-item login failure pattern at line 500-508). Previously the login failure was silently ignored, leaving the user on an empty folder.