### PR TITLE
Fixed: Skip DRM warning when Widevine playback is available

### DIFF
--- a/resources/lib/actions/videoaction.py
+++ b/resources/lib/actions/videoaction.py
@@ -123,6 +123,14 @@ class VideoAction(AddonAction):
 
         if (media_item.isDrmProtected or media_item.isPaid) and AddonSettings.show_drm_paid_warning():
             if media_item.isDrmProtected:
+                try:
+                    import inputstreamhelper
+                    is_helper = inputstreamhelper.Helper("mpd", drm="com.widevine.alpha")
+                    if is_helper.check_inputstream():
+                        Logger.debug("Widevine available, skipping DRM warning regardless of setting")
+                        return
+                except Exception:
+                    pass
                 Logger.debug("Showing DRM Warning message")
                 title = LanguageHelper.get_localized_string(LanguageHelper.DrmTitle)
                 message = LanguageHelper.get_localized_string(LanguageHelper.DrmText)


### PR DESCRIPTION
The DRM warning dialog is unnecessary when inputstreamhelper confirms that InputStream Adaptive and the Widevine CDM are installed. Fall through to the existing warning if the helper is unavailable.

This effectively makes the show_drm_paid_warning setting a no-op when Widevine is present. A future refactor could replace the setting entirely with a pop-up only when Widevine is not detected.