### PR TITLE
Added: Profile-scoped search history in SearchAction

### DIFF
--- a/resources/lib/actions/searchaction.py
+++ b/resources/lib/actions/searchaction.py
@@ -39,7 +39,24 @@ class SearchAction(AddonAction):
         self.__settings = AddonSettings.store(store_location=LOCAL)
         self.__media_item = parameter_parser.media_item
         self.__channel = channel
+        self.__search_key = self.__get_search_key()
         Logger.debug(f"Searching for: {self.__needle}")
+
+    def __get_search_key(self) -> str:
+        """Return the settings key for search history.
+
+        When the channel provides a ``search_profile_id``, the key is scoped
+        to that profile so each profile has its own search history.
+        The active key is persisted so that Menu operations (clear, remove)
+        can find it without instantiating the full channel.
+        """
+        profile_id = self.__channel.search_profile_id
+        if profile_id:
+            key = f"search:{profile_id}"
+        else:
+            key = "search"
+        self.__settings.set_setting("search:active_key", key, self.__channel)
+        return key
 
     def execute(self):
         # read the item from the parameters
@@ -60,13 +77,13 @@ class SearchAction(AddonAction):
                 return
 
             # noinspection PyTypeChecker
-            history: List[str] = self.__settings.get_setting("search", self.__channel, [])  # type: ignore
+            history: List[str] = self.__settings.get_setting(self.__search_key, self.__channel, [])  # type: ignore
             history = [needle] + history
             # de-duplicate without changing order:
             seen = set()
             history = [h for h in history if h not in seen and not seen.add(h)]
 
-            self.__settings.set_setting("search", history[0:10], self.__channel)
+            self.__settings.set_setting(self.__search_key, history[0:10], self.__channel)
 
             # Make sure we actually load a new URL so a refresh won't pop up a loading screen.
             needle = HtmlEntityHelper.url_encode(needle)
@@ -89,7 +106,7 @@ class SearchAction(AddonAction):
 
     def __generate_search_history(self, selected_item: MediaItem, parent_guid: str):
         # noinspection PyTypeChecker
-        history: List[str] = self.__settings.get_setting("search", self.__channel, [])
+        history: List[str] = self.__settings.get_setting(self.__search_key, self.__channel, [])
 
         media_items = []
         search_item = FolderItem(

--- a/resources/lib/chn_class.py
+++ b/resources/lib/chn_class.py
@@ -141,6 +141,18 @@ class Channel:
         return
 
     @property
+    def search_profile_id(self) -> Optional[str]:
+        """Return the active profile ID for profile-scoped search history.
+
+        Channels that support user profiles should override this to return
+        the active profile ID.  When set, SearchAction stores search history
+        per profile instead of per channel.
+
+        :return: The active profile ID, or None if profiles are not supported.
+        """
+        return None
+
+    @property
     def search_url(self) -> str:
         if self.channelCode:
             return (f"plugin://{Config.addonId}/?{keyword.CHANNEL}={self.url_id}"

--- a/resources/lib/menu.py
+++ b/resources/lib/menu.py
@@ -126,22 +126,32 @@ class Menu(ActionParser):
         AddonSettings.show_settings()
         self.refresh()
 
+    def __get_search_key(self) -> str:
+        # SearchAction may store history under a profile-scoped key
+        # (e.g. "search:{profile_id}").  We record the active key so
+        # Menu can find it without instantiating the full channel.
+        settings = AddonSettings.store(LOCAL)
+        key = settings.get_setting("search:active_key", self.channelObject, None)
+        return key or "search"
+
     def clear_search(self):
         """ Clears the complete search history for a channel."""
 
         settings = AddonSettings.store(LOCAL)
-        settings.set_setting("search", [], self.channelObject)
+        settings.set_setting(self.__get_search_key(), [], self.channelObject)
         self.refresh()
 
     def remove_search_item(self):
         """ Removes a single item from the search history for a folder """
 
         settings = AddonSettings.store(LOCAL)
-        history: List[str] = settings.get_setting("search", self.channelObject, [])  # type: ignore
+        key = self.__get_search_key()
+        history: List[str] = settings.get_setting(key, self.channelObject, [])  # type: ignore
         needle: str = self.params[keyword.NEEDLE]
         needle = HtmlEntityHelper.url_decode(needle)
-        history.remove(needle)
-        settings.set_setting("search", history, self.channelObject)
+        if needle in history:
+            history.remove(needle)
+        settings.set_setting(key, history, self.channelObject)
         self.refresh()
 
     def channel_settings(self):

--- a/tests/test_search_history.py
+++ b/tests/test_search_history.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import os
+import unittest
+
+from resources.lib.logger import Logger
+from resources.lib.retroconfig import Config
+from resources.lib.settings.localsettings import LocalSettings
+
+
+class _FakeChannel:
+    """Minimal stand-in for a Channel with an ``id`` attribute."""
+
+    def __init__(self, channel_id):
+        self.id = channel_id
+
+
+class TestSearchHistory(unittest.TestCase):
+    """Verify that profile-scoped search keys produce isolated histories."""
+
+    @classmethod
+    def setUpClass(cls):
+        Logger.create_logger(None, str(cls), min_log_level=0)
+
+    def setUp(self):
+        local_settings_file = os.path.join(Config.profileDir, "settings.json")
+        if os.path.isfile(local_settings_file):
+            os.remove(local_settings_file)
+
+    def _store(self):
+        return LocalSettings(Config.profileDir, Logger.instance())
+
+    def test_no_profile_uses_plain_key(self):
+        """Without a profile, the key is just ``search``."""
+        channel = _FakeChannel("channel.nlziet.nlziet")
+        store = self._store()
+
+        store.set_setting("search", ["cats"], channel)
+        self.assertEqual(store.get_setting("search", channel, []), ["cats"])
+
+    def test_profile_scoped_key(self):
+        """With a profile, the key is ``search:<profile_id>``."""
+        channel = _FakeChannel("channel.nlziet.nlziet")
+        store = self._store()
+
+        key = "search:profile-abc"
+        store.set_setting(key, ["dogs"], channel)
+        self.assertEqual(store.get_setting(key, channel, []), ["dogs"])
+
+    def test_profiles_are_isolated(self):
+        """Different profile keys must not share history."""
+        channel = _FakeChannel("channel.nlziet.nlziet")
+        store = self._store()
+
+        store.set_setting("search:profile-adult", ["thriller"], channel)
+        store.set_setting("search:profile-kids", ["cartoon"], channel)
+
+        self.assertEqual(
+            store.get_setting("search:profile-adult", channel, []),
+            ["thriller"],
+        )
+        self.assertEqual(
+            store.get_setting("search:profile-kids", channel, []),
+            ["cartoon"],
+        )
+
+    def test_profile_key_does_not_affect_plain_key(self):
+        """Profile-scoped history and plain history are independent."""
+        channel = _FakeChannel("channel.nlziet.nlziet")
+        store = self._store()
+
+        store.set_setting("search", ["global"], channel)
+        store.set_setting("search:profile-123", ["scoped"], channel)
+
+        self.assertEqual(store.get_setting("search", channel, []), ["global"])
+        self.assertEqual(
+            store.get_setting("search:profile-123", channel, []), ["scoped"]
+        )


### PR DESCRIPTION
Channels that support user profiles (e.g. kids, adult, named) need isolated search histories so queries from one profile do not appear in another.

Add a search_profile_id property to Channel (returns None by default). When a channel overrides it, SearchAction uses 'search:<profile_id>' as the settings key instead of the plain 'search' key.