### PR TITLE
Fixed: test_chn_urplay NameError for undefined 'headers' variable

### DIFF
--- a/tests/channel_tests/test_chn_urplay.py
+++ b/tests/channel_tests/test_chn_urplay.py
@@ -17,7 +17,7 @@ class TestUrPlayChannel(ChannelTest):
         from resources.lib.urihandler import UriHandler
         from resources.lib.regexer import Regexer
 
-        data = UriHandler.open("https://urplay.se", additional_headers=headers)
+        data = UriHandler.open("https://urplay.se")
         cls._version = Regexer.do_regex(r"<script src=\"[^\"]+/([^/]+)/_buildManifest.js\"", data)[0]
 
     def test_channel_exists(self):


### PR DESCRIPTION
Commit 64df683c introduced additional_headers=headers in setUpClass but the 'headers' variable was never defined, causing a NameError before any test could run. The original call had no additional headers, so revert to the headerless form.