### PR TITLE
Fixed: ChannelImporter skips channel set dirs without JSON manifest

### DIFF
--- a/resources/lib/helpers/channelimporter.py
+++ b/resources/lib/helpers/channelimporter.py
@@ -160,6 +160,9 @@ class ChannelIndex(object):
                     continue
 
                 channel_set_info_path = os.path.join(channel_set_path, "chn_{}.json".format(channel_set))
+                if not os.path.isfile(channel_set_info_path):
+                    Logger.warning(f"Skipping channel set '{channel_set}', no manifest found at: {channel_set_info_path}")
+                    continue
                 channel_infos = ChannelInfo.from_json(channel_set_info_path)
 
                 # Check if the channel was updated


### PR DESCRIPTION
When a channel package directory exists but contains only __pycache__ artifacts (e.g. stale bytecode, unfinished channel), the importer would crash with FileNotFoundError trying to load the missing JSON. Add an isfile() guard to silently skip incomplete channel set dirs.