### PR TITLE
Fixed: KijkNL TypeError when epgDate is null in GraphQL response

### DIFF
--- a/channels/channel.sbsnl/kijknl/chn_kijknl.py
+++ b/channels/channel.sbsnl/kijknl/chn_kijknl.py
@@ -675,7 +675,7 @@ class Channel(chn_class.Channel):
         item.set_info_label("genre", result_set.get("displayGenre"))
         self.__get_artwork(item, result_set.get("imageMedia"))
 
-        if "epgDate" in result_set:
+        if result_set.get("epgDate") is not None:
             time_stamp = result_set["epgDate"] / 1000
             date_stamp = DateHelper.get_date_from_posix(time_stamp, tz=self.__timezone_utc)
             date_stamp = date_stamp.astimezone(self.__timezone)


### PR DESCRIPTION
The epgDate field in the MOVIE query result can be null (None). The previous check 'if "epgDate" in result_set' passes even when the value is None, causing an unsupported operand TypeError when dividing None by 1000 to convert to a POSIX timestamp.