### PR TITLE
Fixed: non-playable NPO IPTV streams.

### DIFF
--- a/channels/channel.nos/nos2010/chn_nos2010.py
+++ b/channels/channel.nos/nos2010/chn_nos2010.py
@@ -1340,13 +1340,17 @@ class Channel(chn_class.Channel):
         }
 
         for livestream in channel_data.json:
+            item_name = JsonHelper.get_from(livestream, "title")
+            if item_name not in logo_sources:
+                continue
+
             item = self.create_api_live_tv(livestream)
             items.append(item)
 
             iptv_streams.append(dict(
                 id=JsonHelper.get_from(livestream, "guid"),
-                name=JsonHelper.get_from(livestream, "title"),
-                logo=logo_sources.get(JsonHelper.get_from(livestream, "title"), ""),
+                name=item_name,
+                logo=logo_sources[item_name],
                 group=self.channelName,
                 stream=parameter_parser.create_action_url(self, action=action.PLAY_VIDEO, item=item,
                                                           store_id=parent_item.guid),

--- a/tests/channel_tests/test_chn_nos2010.py
+++ b/tests/channel_tests/test_chn_nos2010.py
@@ -127,3 +127,13 @@ class TestNpoChannel(ChannelTest):
     def test_update_stream_pow(self):
         url = "KN_1693383"
         self._test_video_url(url)
+
+    def test_iptv_streams(self):
+        from resources.lib.plugin import Plugin
+        result = self.channel.create_iptv_streams(Plugin('plugin.video.restrospect', ''))
+        self.assertEqual(len(result), 6)
+
+    def test_iptv_epg(self):
+        from resources.lib.plugin import Plugin
+        result = self.channel.create_iptv_epg(Plugin('plugin.video.restrospect', ''))
+        self.assertGreaterEqual(len(result), 6)


### PR DESCRIPTION


### Functional description
<!--- Give a clear explanation of the change, fix or new feature
that this PR contains -->
<!--- Put your text below this line -->
Since #1935 Dutch regional channels appear in Kodi's TV section that fail to play.
<!--- Put your text above this line -->

### Reasoning
<!--- Provide a decent justification for this PR -->
<!--- Put your text below this line -->

<!--- Put your text above this line -->

### Technical description
<!--- Please provide a technical analysis of this PR, explaining the
 changes that were made. -->
<!--- Put your text below this line -->
PR #1935 fixed the issues that NPO guide now includes regional channels. However it caused these stations to be included in IPTV channels list and EPG, while there are not playable by the nos2010 channel. This commit excludes non-nos2010 streams from the IPTV streams list.
<!--- Put your text above this line -->

### Tasks & Activities
<!-- What other tasks or activities need to be done to complete
this PR -->

This PR works as a quick fix, but EPG of non-NPO stations is still being fetched, which is a bit inefficient. Dutch regional stations might benefit from EPG, but currently, they are all served by other retrospect channels. 
It might be worth investigating how to implement these stations in nos2010, or find a way not to make requests for EPG of regional channels.
