### PR TITLE
Improved: Lazy-init TextureHandler in ChannelInfo.get_channel()

### DIFF
--- a/resources/lib/channelinfo.py
+++ b/resources/lib/channelinfo.py
@@ -91,6 +91,9 @@ class ChannelInfo(object):
 
         Logger.trace("Importing module %s from path %s", self.moduleName, self.path)
 
+        if not TextureHandler.instance():
+            TextureHandler.set_texture_handler(Config, Logger.instance())
+
         sys.path.append(self.path)
         channel_module = importlib.import_module(self.moduleName)
         try:


### PR DESCRIPTION
Channel.__init__ calls TextureHandler.instance().get_texture_uri() immediately, so any caller of get_channel() would crash if TextureHandler had not been explicitly set up beforehand.

Initializing it lazily inside get_channel() means callers no longer need to know about or manage TextureHandler themselves.