### PR TITLE
Added: Thread exception hook for logging

### DIFF
--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -2,6 +2,7 @@
 
 import os.path
 import sys
+import threading
 
 import xbmc
 
@@ -33,6 +34,13 @@ def run_addon():
                                         Config.appName,
                                         append=append_log_file,
                                         dual_logger=lambda x, y=4: xbmc.log(x, y))
+
+        def _thread_excepthook(args: threading.ExceptHookArgs) -> None:
+            name = args.thread.name if args.thread else "<unknown>"
+            Logger.error("Unhandled exception in thread '%s'", name,
+                         exc_info=(args.exc_type, args.exc_value, args.exc_traceback))
+
+        threading.excepthook = _thread_excepthook
 
         from resources.lib.urihandler import UriHandler
         from resources.lib.addonsettings import AddonSettings


### PR DESCRIPTION
Without a custom threading.excepthook, unhandled exceptions in background threads are dispatched to Python's default handler, which writes to stderr. In a Kodi environment this output is typically discarded, meaning thread failures go completely unnoticed and cannot be diagnosed from the add-on log.

WebDialogue already spawns a daemon thread to run its HTTP server, and as we expand the use of background threads we need these failures to surface in Retrospect's own log rather than be silently dropped. Installing the hook at add-on startup ensures any unhandled thread exception is captured and logged with a full traceback through the normal Logger path.