### PR TITLE
Fixed: Translate network exceptions into status errors

### DIFF
--- a/resources/lib/urihandler.py
+++ b/resources/lib/urihandler.py
@@ -25,6 +25,8 @@ UriStatus = namedtuple('UriStatus', [
     'error'
 ])
 
+URI_STATUS_NETWORK_ERROR = -1
+
 
 class UriHandler(object):
     __handler = None
@@ -536,38 +538,44 @@ class _RequestsHandler(object):
                 # Promote to POST when body arguments are present
                 http_method = "POST" if has_body else "GET"
 
-            if http_method == "GET":
-                Logger.info("Performing a GET for %s", uri)
-                r = s.get(uri, proxies=proxies, headers=headers,
-                          stream=stream, timeout=self.webTimeOut)
+            try:
+                if http_method == "GET":
+                    Logger.info("Performing a GET for %s", uri)
+                    r = s.get(uri, proxies=proxies, headers=headers,
+                              stream=stream, timeout=self.webTimeOut)
 
-            elif http_method == "POST":
-                body_data, body_json = data, json
-                if params is not None:
-                    # Old UriHandler behavior. Set form header to keep compatible
-                    if "content-type" not in headers:
-                        headers["content-type"] = "application/x-www-form-urlencoded"
-                    body_data, body_json = params, None
-                Logger.info("Performing a POST with '%s' for %s",
-                            headers.get("content-type", "<No Content-Type>"), uri)
-                r = s.post(uri, data=body_data, json=body_json,
-                           proxies=proxies, headers=headers,
-                           stream=stream, timeout=self.webTimeOut)
+                elif http_method == "POST":
+                    body_data, body_json = data, json
+                    if params is not None:
+                        # Old UriHandler behavior. Set form header to keep compatible
+                        if "content-type" not in headers:
+                            headers["content-type"] = "application/x-www-form-urlencoded"
+                        body_data, body_json = params, None
+                    Logger.info("Performing a POST with '%s' for %s",
+                                headers.get("content-type", "<No Content-Type>"), uri)
+                    r = s.post(uri, data=body_data, json=body_json,
+                               proxies=proxies, headers=headers,
+                               stream=stream, timeout=self.webTimeOut)
 
-            elif http_method == "PATCH":
-                Logger.info("Performing a PATCH with '%s' for %s",
-                            headers.get("content-type", "<No Content-Type>"), uri)
-                r = s.patch(uri, data=data, json=json, proxies=proxies,
-                            headers=headers, stream=stream,
-                            timeout=self.webTimeOut)
+                elif http_method == "PATCH":
+                    Logger.info("Performing a PATCH with '%s' for %s",
+                                headers.get("content-type", "<No Content-Type>"), uri)
+                    r = s.patch(uri, data=data, json=json, proxies=proxies,
+                                headers=headers, stream=stream,
+                                timeout=self.webTimeOut)
 
-            elif http_method == "DELETE":
-                Logger.info("Performing a DELETE for %s", uri)
-                r = s.delete(uri, proxies=proxies, headers=headers,
-                             stream=stream, timeout=self.webTimeOut)
+                elif http_method == "DELETE":
+                    Logger.info("Performing a DELETE for %s", uri)
+                    r = s.delete(uri, proxies=proxies, headers=headers,
+                                 stream=stream, timeout=self.webTimeOut)
 
-            else:
-                raise ValueError("Unsupported HTTP Method %s" % http_method)
+                else:
+                    raise ValueError("Unsupported HTTP Method %s" % http_method)
+
+            except OSError as e:
+                Logger.error("Network error for %s", uri, exc_info=True)
+                self.status = UriStatus(code=URI_STATUS_NETWORK_ERROR, url=uri, error=True, reason=str(e))
+                return None
 
             if r.ok:
                 Logger.info("%s resulted in '%s %s' (%s) for %s",

--- a/resources/lib/urihandler.py
+++ b/resources/lib/urihandler.py
@@ -536,38 +536,44 @@ class _RequestsHandler(object):
                 # Promote to POST when body arguments are present
                 http_method = "POST" if has_body else "GET"
 
-            if http_method == "GET":
-                Logger.info("Performing a GET for %s", uri)
-                r = s.get(uri, proxies=proxies, headers=headers,
-                          stream=stream, timeout=self.webTimeOut)
+            try:
+                if http_method == "GET":
+                    Logger.info("Performing a GET for %s", uri)
+                    r = s.get(uri, proxies=proxies, headers=headers,
+                              stream=stream, timeout=self.webTimeOut)
 
-            elif http_method == "POST":
-                body_data, body_json = data, json
-                if params is not None:
-                    # Old UriHandler behavior. Set form header to keep compatible
-                    if "content-type" not in headers:
-                        headers["content-type"] = "application/x-www-form-urlencoded"
-                    body_data, body_json = params, None
-                Logger.info("Performing a POST with '%s' for %s",
-                            headers.get("content-type", "<No Content-Type>"), uri)
-                r = s.post(uri, data=body_data, json=body_json,
-                           proxies=proxies, headers=headers,
-                           stream=stream, timeout=self.webTimeOut)
+                elif http_method == "POST":
+                    body_data, body_json = data, json
+                    if params is not None:
+                        # Old UriHandler behavior. Set form header to keep compatible
+                        if "content-type" not in headers:
+                            headers["content-type"] = "application/x-www-form-urlencoded"
+                        body_data, body_json = params, None
+                    Logger.info("Performing a POST with '%s' for %s",
+                                headers.get("content-type", "<No Content-Type>"), uri)
+                    r = s.post(uri, data=body_data, json=body_json,
+                               proxies=proxies, headers=headers,
+                               stream=stream, timeout=self.webTimeOut)
 
-            elif http_method == "PATCH":
-                Logger.info("Performing a PATCH with '%s' for %s",
-                            headers.get("content-type", "<No Content-Type>"), uri)
-                r = s.patch(uri, data=data, json=json, proxies=proxies,
-                            headers=headers, stream=stream,
-                            timeout=self.webTimeOut)
+                elif http_method == "PATCH":
+                    Logger.info("Performing a PATCH with '%s' for %s",
+                                headers.get("content-type", "<No Content-Type>"), uri)
+                    r = s.patch(uri, data=data, json=json, proxies=proxies,
+                                headers=headers, stream=stream,
+                                timeout=self.webTimeOut)
 
-            elif http_method == "DELETE":
-                Logger.info("Performing a DELETE for %s", uri)
-                r = s.delete(uri, proxies=proxies, headers=headers,
-                             stream=stream, timeout=self.webTimeOut)
+                elif http_method == "DELETE":
+                    Logger.info("Performing a DELETE for %s", uri)
+                    r = s.delete(uri, proxies=proxies, headers=headers,
+                                 stream=stream, timeout=self.webTimeOut)
 
-            else:
-                raise ValueError("Unsupported HTTP Method %s" % http_method)
+                else:
+                    raise ValueError("Unsupported HTTP Method %s" % http_method)
+
+            except OSError as e:
+                Logger.error("Network error for %s", uri, exc_info=True)
+                self.status = UriStatus(code=0, url=uri, error=True, reason=str(e))
+                return None
 
             if r.ok:
                 Logger.info("%s resulted in '%s %s' (%s) for %s",


### PR DESCRIPTION
No call site should need to guard against OSError from UriHandler.open(). The entire call chain — from channel methods through the Action layer — is built around checking UriHandler.instance().status.error after every request. Requiring individual callers to also wrap in try/except would be a leaky abstraction that is easy to miss and hard to enforce consistently.

Network-level failures (connection refused, DNS failure, timeout) are now caught inside __requests() and translated into the same status.error signal that HTTP failures already produce. The contract is now: UriHandler.open() never raises.

In this context, catching OSError is sufficient: in Python 3, IOError is an alias for OSError, and all requests network exceptions (ConnectionError, Timeout, etc.) inherit from it. No non-network OSErrors can arise from an HTTP call.

ValueErrors raised by UriHandler (unsupported HTTP method, missing download destination, missing callback, etc.) are deliberately left to propagate — they all signal programming errors, not runtime conditions, and are caught by the Action framework's broad exception handler.