### PR TITLE
Changed: Use modern default User-Agent

### DIFF
--- a/resources/lib/helpers/useragenthelper.py
+++ b/resources/lib/helpers/useragenthelper.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import json
+import os
+import time
+from typing import List, Optional
+
+from resources.lib.logger import Logger
+from resources.lib.retroconfig import Config
+
+
+_SECONDS_PER_DAY = 24 * 60 * 60
+_USER_AGENTS_URL = "https://jnrbsn.github.io/user-agents/user-agents.json"
+_USER_AGENTS_CACHE_DAYS = 7
+_USER_AGENTS_CACHE_FILE = "user_agent_cache.json"
+_USER_AGENTS_FETCH_TIMEOUT = 5
+FALLBACK_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36"
+)
+
+
+class UserAgentHelper(object):
+    """Resolve the default modern User-Agent for outbound web requests."""
+
+    def __init__(self):
+        raise NotImplementedError()
+
+
+    @staticmethod
+    def _fetch_and_cache_user_agents(source_url: str, cache_filename: str) -> Optional[List[str]]:
+        """Fetch a fresh user-agent list from source and write it to cache."""
+
+        try:
+            import requests as _requests
+            Logger.debug("UserAgent: Fetching fresh user agents list")
+            response = _requests.get(source_url, timeout=_USER_AGENTS_FETCH_TIMEOUT)
+            if response.status_code != 200:
+                Logger.warning(f"UserAgent: Fetch returned HTTP {response.status_code}")
+                return None
+
+            user_agents = response.json()
+            if (not isinstance(user_agents, list) or
+                not user_agents):
+                Logger.warning(f"UserAgent: Expected list, got {type(user_agents).__name__}")
+                return None
+
+            os.makedirs(Config.cacheDir, exist_ok=True)
+            cache_path = os.path.join(Config.cacheDir, cache_filename)
+            with open(cache_path, 'w') as f:
+                json.dump(user_agents, f)
+
+            Logger.debug(f"UserAgent: Cached {len(user_agents)} user agents")
+            return user_agents
+        except Exception as e:
+            Logger.error(f"UserAgent: Failed to fetch user agents: {e}")
+            return None
+
+
+    @staticmethod
+    def _load_cached_user_agents(cache_filename: str, max_age_days: int) -> Optional[List[str]]:
+        """Load cached user agents if the cache is still fresh."""
+
+        cache_path = os.path.join(Config.cacheDir, cache_filename)
+        if not os.path.exists(cache_path):
+            return None
+
+        try:
+            cache_mtime = os.path.getmtime(cache_path)
+            cache_age_seconds = time.time() - cache_mtime
+            max_age_seconds = max_age_days * _SECONDS_PER_DAY
+            if cache_age_seconds >= max_age_seconds:
+                return None
+
+            with open(cache_path, 'r') as f:
+                user_agents = json.load(f)
+
+            if (not isinstance(user_agents, list) or
+                not user_agents):
+                Logger.warning(f"UserAgent: Expected cached list, got {type(user_agents).__name__}")
+                return None
+
+            Logger.trace("UserAgent: Using cached user agents")
+            return user_agents
+        except (OSError, ValueError, TypeError) as e:
+            Logger.warning(f"UserAgent: Failed to load cached user agents: {e}")
+            return None
+
+
+    @staticmethod
+    def get_user_agent() -> str:
+        """
+        Return a modern default User-Agent string.
+
+        Tries the local cache first. On a cache miss, fetches a fresh list from
+        the upstream source and caches it. Falls back to the bundled modern
+        browser User-Agent if both fail.
+        """
+
+        user_agents = UserAgentHelper._load_cached_user_agents(
+            _USER_AGENTS_CACHE_FILE,
+            _USER_AGENTS_CACHE_DAYS
+        )
+        if not user_agents:
+            user_agents = UserAgentHelper._fetch_and_cache_user_agents(
+                _USER_AGENTS_URL,
+                _USER_AGENTS_CACHE_FILE
+            )
+        if user_agents:
+            return user_agents[0]
+
+        Logger.debug("UserAgent: Using fallback user agent")
+        return FALLBACK_USER_AGENT

--- a/resources/lib/urihandler.py
+++ b/resources/lib/urihandler.py
@@ -14,6 +14,7 @@ import requests.utils
 
 from resources.lib.connectivity.cachehttpadapter import CacheHTTPAdapter
 from resources.lib.connectivity.streamcache import StreamCache
+from resources.lib.helpers.useragenthelper import UserAgentHelper
 from resources.lib.logger import Logger
 from resources.lib.proxyinfo import ProxyInfo
 
@@ -336,7 +337,6 @@ class _RequestsHandler(object):
         else:
             Logger.debug("No cache-store provided. Cached disabled.")
 
-        self.userAgent = "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-GB; rv:1.9.2.13) Gecko/20101203 Firefox/3.6.13 (.NET CLR 3.5.30729)"
         self.webTimeOut = web_time_out                # max duration of request
         self.ignoreSslErrors = ignore_ssl_errors      # ignore SSL errors
         if self.ignoreSslErrors:
@@ -589,7 +589,8 @@ class _RequestsHandler(object):
                 headers[k.lower()] = v
 
         if "user-agent" not in headers:
-            headers["user-agent"] = self.userAgent
+            headers["user-agent"] = UserAgentHelper.get_user_agent()
+
         if referer and "referer" not in headers:
             headers["referer"] = referer
 

--- a/tests/test_urihandler.py
+++ b/tests/test_urihandler.py
@@ -3,6 +3,7 @@
 
 
 import unittest
+import unittest.mock
 import os
 import json
 import tempfile
@@ -191,13 +192,14 @@ class TestUriHandler(unittest.TestCase):
         self.assertEqual([header_value], data["headers"][header_name])
         self.assertEqual(200, UriHandler.instance().status.code)
 
-    def test_user_agent(self):
+    @unittest.mock.patch("resources.lib.urihandler.UserAgentHelper.get_user_agent")
+    def test_user_agent(self, mock_get_user_agent: unittest.mock.MagicMock) -> None:
         UriHandler.create_uri_handler()
         url = self.base_url + "/headers"
         header_name = "User-Agent"
 
-        # standard header first, the one from code
-        header_value = "Mozilla/5.0 (Windows; U; Windows NT 6.1; en-GB; rv:1.9.2.13) Gecko/20101203 Firefox/3.6.13 (.NET CLR 3.5.30729)"
+        header_value = "ModernUserAgent/5.0"
+        mock_get_user_agent.return_value = header_value
         data = UriHandler.open(url)
         self.assertIsNot("", data)
         data = json.loads(data)
@@ -211,6 +213,7 @@ class TestUriHandler(unittest.TestCase):
         data = json.loads(data)
         self.assertEqual([header_value], data["headers"][header_name])
         self.assertEqual(200, UriHandler.instance().status.code)
+
 
     def test_referer(self):
         UriHandler.create_uri_handler()

--- a/tests/test_useragenthelper.py
+++ b/tests/test_useragenthelper.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import unittest
+import unittest.mock
+
+from resources.lib.helpers.useragenthelper import FALLBACK_USER_AGENT, UserAgentHelper
+
+
+class TestUserAgentHelper(unittest.TestCase):
+
+    @unittest.mock.patch("resources.lib.helpers.useragenthelper.UserAgentHelper._load_cached_user_agents")
+    def test_get_user_agent_prefers_cached_value(
+            self, mock_load: unittest.mock.MagicMock) -> None:
+        """get_user_agent() returns the freshest cached browser User-Agent."""
+
+        mock_load.return_value = ["Browser/2.0", "Browser/1.0"]
+
+        self.assertEqual("Browser/2.0", UserAgentHelper.get_user_agent())
+
+
+    @unittest.mock.patch("resources.lib.helpers.useragenthelper.UserAgentHelper._fetch_and_cache_user_agents")
+    @unittest.mock.patch("resources.lib.helpers.useragenthelper.UserAgentHelper._load_cached_user_agents")
+    def test_get_user_agent_fetches_when_cache_missing(
+            self,
+            mock_load: unittest.mock.MagicMock,
+            mock_fetch: unittest.mock.MagicMock) -> None:
+        """get_user_agent() fetches from upstream when the cache is empty."""
+
+        mock_load.return_value = None
+        mock_fetch.return_value = ["Fetched/3.0"]
+
+        self.assertEqual("Fetched/3.0", UserAgentHelper.get_user_agent())
+        mock_fetch.assert_called_once()
+
+
+    @unittest.mock.patch("resources.lib.helpers.useragenthelper.UserAgentHelper._fetch_and_cache_user_agents")
+    @unittest.mock.patch("resources.lib.helpers.useragenthelper.UserAgentHelper._load_cached_user_agents")
+    def test_get_user_agent_uses_fallback_when_fetch_fails(
+            self,
+            mock_load: unittest.mock.MagicMock,
+            mock_fetch: unittest.mock.MagicMock) -> None:
+        """get_user_agent() falls back to the bundled UA when cache and fetch both fail."""
+
+        mock_load.return_value = None
+        mock_fetch.return_value = None
+
+        self.assertEqual(FALLBACK_USER_AGENT, UserAgentHelper.get_user_agent())


### PR DESCRIPTION
Add modern rotating User-Agent [0] resolution into a dedicated UserAgentHelper class. UriHandler now delegates to it instead of keeping a hardcoded legacy Firefox 3.6 string.

[0]: https://github.com/jnrbsn/user-agents