### PR TITLE
Fix Videoland watched/resume state persistence

### DIFF
--- a/channels/channel.videoland/videolandnl/chn_videolandnl.py
+++ b/channels/channel.videoland/videolandnl/chn_videolandnl.py
@@ -241,7 +241,7 @@ class Channel(chn_class.Channel):
                 mins, _ = others.split("min")
             elif "min" in time_value:
                 mins, _ = time_value.split("min")
-            item.set_info_label(MediaItem.LabelDuration, 60 * int(hours) + int(mins))
+            item.set_info_label(MediaItem.LabelDuration, 3600 * int(hours) + 60 * int(mins))
 
         date_value = (result_set["details"] or "").lower()
         if date_value:
@@ -312,7 +312,9 @@ class Channel(chn_class.Channel):
             return None
 
         title = result_set["title"].get("long", result_set["title"].get("short"))
-        page_id = result_set["id"]
+        # Bedrock returns block ids as "page_<cache-buster>--<stable-id>"; the prefix changes
+        # per request and would make MediaItem.guid unstable, breaking Kodi watched/resume tracking.
+        page_id = result_set["id"].split("--", 1)[-1]
         url = f"https://layout.videoland.bedrock.tech/front/v1/rtlnl/m6group_web/main/token-web-4/program/{self.__program_id}/block/{page_id}?nbPages=10&page=1"
         item = FolderItem(title, url, content_type=contenttype.EPISODES)
 


### PR DESCRIPTION
Two root causes prevented Kodi from persisting watched status and resume points for Videoland episodes across visits/restarts:

1. Season block `page_id` from the Bedrock API has the shape `page_<cache-buster>--<stable-id>`. The prefix changes on every request, so the season folder URL (and thus its MediaItem.guid) differed per visit. Since child episode plugin URLs embed the parent guid, Kodi could not match its stored state on re-entry. Strip the cache-buster before building the URL.

2. `create_content_item` stored duration in minutes while Kodi expects seconds. A 45-minute episode was reported as 45s, which caused any brief playback to register as >100% watched and suppressed resume tracking.
