### PR TITLE
Drop automatic episode-number prefix on Videoland seasons

### DIFF
--- a/channels/channel.videoland/videolandnl/chn_videolandnl.py
+++ b/channels/channel.videoland/videolandnl/chn_videolandnl.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import datetime
-import re
 from typing import Union, List, Optional, Tuple
 
 import pytz
@@ -268,28 +267,14 @@ class Channel(chn_class.Channel):
         return json_data, []
 
     def postprocess_episodes(self, data, items: List[MediaItem]) -> List[MediaItem]:
-        # Season episodes can be named ["Aflevering 1", "Aflevering 2"] and so on, or ["Some episode name", "Another episode name", "Yet another episode name"]
-        # without an episode number. Some episodes have a date, and some have no date, even within a single season.
-
-        # All this messes up Kodi episode ordering by either date or name:
-        # If no episodes have a date, Kodi orders by name, so "Another episode name" becomes the first episode instead of the second.
-        # If some episodes have a date and some later ones don't, Kodi shows the later ones as the first episodes (mindate), followed by the ones with a date.
-
-        # This postprocessing function fixes name ordering by adding an episode number in front of the title if the episodes
-        # are not like "Aflevering 1", "Aflevering 2" and so on.
-        # Episode names become ["01 Some episode name", "02 Another episode name", "03 Yet another episode name"].
-        # Numbered episodes are fairly common, and in this case it is useful to achieve the right sort order by name.
-
-        # This postprocessing function fixes date ordering by setting the date of an episode, if it has no date, to the date of the previous episode.
-        # This is probably not the real broadcast date, but it at least fixes the order.
+        # Some episodes have a date and others within the same season don't. Kodi then treats the
+        # undated ones as mindate and shows them first. Fill in the previous episode's date so the
+        # chronological order still makes sense.
         if (len(items) > 1
                 and data.json.get("featureId") == "videos_by_season_by_program"
-                and all(item.media_type == mediatype.EPISODE
-                        and not re.match(r"[Aa]flevering \d+", item.name) for item in
-                        items)):
+                and all(item.media_type == mediatype.EPISODE for item in items)):
             date = ""
-            for index, item in enumerate(items, start=1):
-                item.name = f"{index:02} {item.name}"
+            for item in items:
                 if not item.has_date() and date:
                     previous_episode_date = DateHelper.get_datetime_from_string(date, "%Y-%m-%d")
                     item.set_date(previous_episode_date.year, previous_episode_date.month,

--- a/tests/channel_tests/test_chn_videoland.py
+++ b/tests/channel_tests/test_chn_videoland.py
@@ -19,36 +19,8 @@ class TestVideolandNLChannel(ChannelTest):
     def test_channel_exists(self):
         self.assertIsNotNone(self.channel)
 
-    def test_episode_number_added_for_season(self):
+    def test_episode_names_unchanged_for_season(self):
         data = self.JsonWrapper({"featureId": "videos_by_season_by_program"})
-        items = [
-            self.create_media_item("Some episode name"),
-            self.create_media_item("Another episode name"),
-            self.create_media_item("Yet another episode name"),
-        ]
-
-        changed = self.channel.postprocess_episodes(data, items)
-        self.assertCountEqual(changed, items)
-        self.assertEqual(changed[0].name, "01 Some episode name")
-        self.assertEqual(changed[1].name, "02 Another episode name")
-        self.assertEqual(changed[2].name, "03 Yet another episode name")
-
-    def test_episode_number_not_added_for_other_than_episode(self):
-        data = self.JsonWrapper({"featureId": "videos_by_season_by_program"})
-        items = [
-            self.create_media_item("Some episode name", "no_episode"),
-            self.create_media_item("Another episode name", "no_episode"),
-            self.create_media_item("Yet another episode name", "no_episode"),
-        ]
-
-        changed = self.channel.postprocess_episodes(data, items)
-        self.assertCountEqual(changed, items)
-        self.assertEqual(changed[0].name, "Some episode name")
-        self.assertEqual(changed[1].name, "Another episode name")
-        self.assertEqual(changed[2].name, "Yet another episode name")
-
-    def test_episode_number_not_added_for_other_list(self):
-        data = self.JsonWrapper({"featureId": "other"})
         items = [
             self.create_media_item("Some episode name"),
             self.create_media_item("Another episode name"),
@@ -61,22 +33,7 @@ class TestVideolandNLChannel(ChannelTest):
         self.assertEqual(changed[1].name, "Another episode name")
         self.assertEqual(changed[2].name, "Yet another episode name")
 
-    def test_episode_number_not_added_for_aflevering(self):
-        data = self.JsonWrapper({"featureId": "videos_by_season_by_program"})
-        # Episodes ordered backwards
-        items = [
-            self.create_media_item("Aflevering 3"),
-            self.create_media_item("Aflevering 2"),
-            self.create_media_item("Aflevering 1"),
-        ]
-
-        changed = self.channel.postprocess_episodes(data, items)
-        self.assertCountEqual(changed, items)
-        self.assertEqual(changed[0].name, "Aflevering 3")
-        self.assertEqual(changed[1].name, "Aflevering 2")
-        self.assertEqual(changed[2].name, "Aflevering 1")
-
-    def test_episode_number_date_filled_in(self):
+    def test_episode_date_filled_in(self):
         data = self.JsonWrapper({"featureId": "videos_by_season_by_program"})
         items = [
             self.create_media_item("Some episode name", date="2022-07-05"),
@@ -86,9 +43,9 @@ class TestVideolandNLChannel(ChannelTest):
 
         changed = self.channel.postprocess_episodes(data, items)
         self.assertCountEqual(changed, items)
-        self.assertEqual(changed[0].name, "01 Some episode name")
-        self.assertEqual(changed[1].name, "02 Another episode name")
-        self.assertEqual(changed[2].name, "03 Yet another episode name [date unknown]")
+        self.assertEqual(changed[0].name, "Some episode name")
+        self.assertEqual(changed[1].name, "Another episode name")
+        self.assertEqual(changed[2].name, "Yet another episode name [date unknown]")
         self.assertTrue(changed[0].has_date())
         self.assertTrue(changed[1].has_date())
         self.assertTrue(changed[2].has_date())


### PR DESCRIPTION
postprocess_episodes prepended "NN " to every episode title to force a correct sort order in Kodi, turning "Pilot" into "01 Pilot". The prefix is intrusive and the underlying sort problem for dated episodes is already handled by back-filling missing dates from the previous episode, so keep only that date-filling behaviour.

Simplifies the guard (no more "Aflevering N" exception) and drops the now-unused `re` import. Tests are rewritten to cover the remaining name-unchanged and date-filled cases.

Also the numbering was wrong for like "kopen zonder kijken":
01 Aflevering 09 
02 Aflevering 08
etc.