### PR TITLE
Boyscout: Accept 'None' in __safe_log

### DIFF
--- a/resources/lib/authentication/authenticator.py
+++ b/resources/lib/authentication/authenticator.py
@@ -114,5 +114,14 @@ class Authenticator(object):
             else:
                 Logger.error("Log off failed")
 
-    def __safe_log(self, text):
+    def __safe_log(self, text: Optional[str]) -> Optional[str]:
+        """ Obfuscate a string for logging by masking every odd-positioned character.
+
+        :param text:    The string to obfuscate, or None.
+        :returns:       Obfuscated string, or None if input was empty/None.
+
+        """
+
+        if not text:
+            return None
         return "".join([text[i] if i % 2 == 0 else "*" for i in range(0, len(text))])

--- a/tests/authentication/test_authenticator.py
+++ b/tests/authentication/test_authenticator.py
@@ -107,3 +107,19 @@ class TestAuthenticator(unittest.TestCase):
         res = a.log_on(user_name, self.password)
         self.assertTrue(res.logged_on)
         self.assertEqual(user_name, a.active_authentication().username)
+
+    def test_safe_log_masks_odd_indices(self):
+        h = RtlXlHandler("rtlxl.nl", self.rtl_api_key)
+        a = Authenticator(h)
+        self.assertEqual(a._Authenticator__safe_log("user@example.com"),
+                         "u*e*@*x*m*l*.*o*")
+
+    def test_safe_log_passes_none_through(self):
+        h = RtlXlHandler("rtlxl.nl", self.rtl_api_key)
+        a = Authenticator(h)
+        self.assertIsNone(a._Authenticator__safe_log(None))
+
+    def test_safe_log_collapses_empty_string_to_none(self):
+        h = RtlXlHandler("rtlxl.nl", self.rtl_api_key)
+        a = Authenticator(h)
+        self.assertIsNone(a._Authenticator__safe_log(""))


### PR DESCRIPTION
The masking helper was typed strictly as str -> str, but log call sites in upcoming refactors will pass Optional[str] (e.g. usernames retrieved from session checks before the not-None guard). Widen the signature to Optional[str] -> Optional[str] and collapse any falsy input to None, so callers can drop their `if x else None` fallbacks at the call site.

Empty strings collapse to None as well: the helper produces a redacted display string for logs, and an empty string isn't a redacted display of anything -- it's an absence. One sentinel beats two.

Add tests pinning the masking format and the None / empty-string collapse behavior. The helper had no test coverage before.

Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>

### Functional description
<!--- Give a clear explanation of the change, fix or new feature
that this PR contains -->
<!--- Put your text below this line -->

<!--- Put your text above this line -->

### Reasoning
<!--- Provide a decent justification for this PR -->
<!--- Put your text below this line -->

<!--- Put your text above this line -->

### Technical description
<!--- Please provide a technical analysis of this PR, explaining the
 changes that were made. -->
<!--- Put your text below this line -->

<!--- Put your text above this line -->

### Tasks & Activities
<!-- What other tasks or activities need to be done to complete
this PR -->

- [ ] Activity 1
- [ ] Activity 2
