### PR TITLE
Fixed: Vault defers PIN creation to first write

### DIFF
--- a/resources/lib/vault.py
+++ b/resources/lib/vault.py
@@ -26,28 +26,38 @@ class Vault(object):
 
         self.__newKeyGeneratedInConstructor = False    # : This was the very first time a key was generated
 
-        # ask for PIN of no key is present
         if Vault.__Key is None:
-            howto_shown = self.__show_howto()
             key = self.__get_application_key()  # type: bytes
+            if key is not None:
+                Vault.__Key = key
+                Logger.trace("Using Application Key with MD5: %s (length=%s)",
+                             EncodingHelper.encode_md5(key), len(key))
 
-            # was there a key? No, let's initialize it.
-            if key is None:
-                Logger.warning("No Application Key present. Initializing a new one.")
+    def _initialize_vault(self):
+        """ Initializes the vault on first write by generating a key and asking the user to set a PIN.
 
-                # Show the how to if it was not already shown during this __init__()
-                if not howto_shown:
-                    self.__show_howto(force=True)
+        No-op if the vault is already unlocked.
 
-                key = self.__get_new_key()
-                if not self.change_pin(key):
-                    raise RuntimeError("Error creating Application Key.")
-                Logger.info("Created a new Application Key with MD5: %s (length=%s)",
-                            EncodingHelper.encode_md5(key), len(key))
-                self.__newKeyGeneratedInConstructor = True
+        :returns:   True if the vault is ready, False if PIN setup was cancelled or failed.
+        :rtype:     bool
 
-            Vault.__Key = key
-            Logger.trace("Using Application Key with MD5: %s (length=%s)", EncodingHelper.encode_md5(key), len(key))
+        """
+
+        if Vault.__Key is not None:
+            return True
+
+        Logger.warning("No Application Key present. Initializing a new one.")
+        self.__show_howto(force=True)
+        key = self.__get_new_key()
+        if not self.change_pin(key):
+            Logger.warning("Vault initialization failed: PIN setup was cancelled or mismatched.")
+            return False
+        Logger.info("Created a new Application Key with MD5: %s (length=%s)",
+                    EncodingHelper.encode_md5(key), len(key))
+        self.__newKeyGeneratedInConstructor = True
+        Vault.__Key = key
+        return True
+
 
     def change_pin(self, application_key=None):
         """ Stores an existing ApplicationKey using a new PIN.
@@ -125,9 +135,9 @@ class Vault(object):
 
         Logger.info("Resetting the vault to a new initial state.")
         AddonSettings.set_setting(Vault.__APPLICATION_KEY_SETTING, "", store=LOCAL)
-
-        # create a vault instance so we initialize a new one with a new PIN.
-        Vault()
+        Vault.__Key = None
+        if not Vault()._initialize_vault():
+            Logger.warning("Vault reset incomplete: PIN setup was cancelled.")
         return
 
     def get_channel_setting(self, channel_guid, setting_id):
@@ -151,6 +161,10 @@ class Vault(object):
         :return: the decrypted value for the setting.
         :rtype: str
         """
+
+        if Vault.__Key is None:
+            Logger.debug("Vault not initialised; returning None for '%s'", setting_id)
+            return None
 
         Logger.info("Decrypting value for setting '%s'", setting_id)
         encrypted_value = AddonSettings.get_setting(setting_id)
@@ -204,6 +218,8 @@ class Vault(object):
 
         """
 
+        if not self._initialize_vault():
+            return
         Logger.info("Encrypting value for setting '%s'", setting_id)
         input_value = XbmcWrapper.show_key_board(
             default, LanguageHelper.get_localized_string(

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -1,0 +1,202 @@
+# coding=utf-8  # NOSONAR
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+from resources.lib.vault import Vault
+
+
+def _reset_vault_key():
+    Vault._Vault__Key = None
+
+
+class TestVaultGetWithoutKey(unittest.TestCase):
+    """get_* returns None silently when the vault has never been initialised."""
+
+    def setUp(self):
+        _reset_vault_key()
+
+    def tearDown(self):
+        _reset_vault_key()
+
+    @patch("resources.lib.vault.AddonSettings")
+    @patch("resources.lib.vault.XbmcWrapper")
+    def test_get_setting_returns_none_without_vault(self, mock_xbmc, mock_settings):
+        """SUCCESS → None returned, no PIN or howto dialog shown."""
+
+        mock_settings.get_setting.return_value = None
+
+        v = Vault()
+        result = v.get_setting("some_setting")
+
+        self.assertIsNone(result)
+        mock_xbmc.show_key_board.assert_not_called()
+        mock_xbmc.show_text.assert_not_called()
+
+    @patch("resources.lib.vault.AddonSettings")
+    @patch("resources.lib.vault.XbmcWrapper")
+    def test_get_channel_setting_returns_none_without_vault(self, mock_xbmc, mock_settings):
+        """SUCCESS → None returned, no PIN or howto dialog shown."""
+
+        mock_settings.get_setting.return_value = None
+
+        v = Vault()
+        result = v.get_channel_setting("guid-123", "my_setting")
+
+        self.assertIsNone(result)
+        mock_xbmc.show_key_board.assert_not_called()
+        mock_xbmc.show_text.assert_not_called()
+
+
+class TestVaultInit(unittest.TestCase):
+    """Vault.__init__ is silent when no key is stored — no prompts of any kind."""
+
+    def setUp(self):
+        _reset_vault_key()
+
+    def tearDown(self):
+        _reset_vault_key()
+
+    @patch("resources.lib.vault.AddonSettings")
+    @patch("resources.lib.vault.XbmcWrapper")
+    def test_init_does_not_prompt_when_no_key_stored(self, mock_xbmc, mock_settings):
+        """SUCCESS → constructor emits no dialogs when the vault has never been set up."""
+
+        mock_settings.get_setting.return_value = None
+
+        Vault()
+
+        mock_xbmc.show_key_board.assert_not_called()
+        mock_xbmc.show_text.assert_not_called()
+        mock_xbmc.show_dialog.assert_not_called()
+        self.assertIsNone(Vault._Vault__Key)
+
+
+class TestVaultSetTriggersInit(unittest.TestCase):
+    """set_* triggers PIN setup when vault is not yet initialised."""
+
+    def setUp(self):
+        _reset_vault_key()
+
+    def tearDown(self):
+        _reset_vault_key()
+
+    @patch("resources.lib.vault.AddonSettings")
+    @patch("resources.lib.vault.XbmcWrapper")
+    def test_set_setting_triggers_howto_and_pin_when_no_vault(self, mock_xbmc, mock_settings):
+        """SUCCESS → howto shown and PIN dialogs fired before storing the value."""
+
+        mock_settings.get_setting.return_value = None
+        mock_settings.get_client_id.return_value = "test-client-id"
+        mock_xbmc.show_key_board.side_effect = ["mypin", "mypin", "mysecret"]
+
+        v = Vault()
+        v.set_setting("my_setting", setting_name="My Password")
+
+        mock_xbmc.show_text.assert_called_once()
+        self.assertGreaterEqual(mock_xbmc.show_key_board.call_count, 2)
+
+    @patch("resources.lib.vault.AddonSettings")
+    @patch("resources.lib.vault.XbmcWrapper")
+    def test_set_setting_does_not_trigger_init_when_vault_already_set(
+            self, mock_xbmc, mock_settings):
+        """SUCCESS → no howto shown when vault key already cached."""
+
+        Vault._Vault__Key = b"a" * 32
+        mock_xbmc.show_key_board.return_value = "mysecret"
+
+        v = Vault()
+        v.set_setting("my_setting", setting_name="My Password")
+
+        mock_xbmc.show_text.assert_not_called()
+
+    @patch("resources.lib.vault.AddonSettings")
+    @patch("resources.lib.vault.XbmcWrapper")
+    def test_set_channel_setting_triggers_howto_and_pin_when_no_vault(
+            self, mock_xbmc, mock_settings):
+        """SUCCESS → howto and PIN setup triggered via set_channel_setting when no key exists."""
+
+        mock_settings.get_setting.return_value = None
+        mock_settings.get_client_id.return_value = "test-client-id"
+        mock_xbmc.show_key_board.side_effect = ["mypin", "mypin", "mysecret"]
+
+        v = Vault()
+        v.set_channel_setting("guid-abc", "password", setting_name="Channel Password")
+
+        mock_xbmc.show_text.assert_called_once()
+        self.assertGreaterEqual(mock_xbmc.show_key_board.call_count, 2)
+
+    @patch("resources.lib.vault.AddonSettings")
+    @patch("resources.lib.vault.XbmcWrapper")
+    def test_set_setting_does_not_encrypt_when_pin_setup_cancelled(self, mock_xbmc, mock_settings):
+        """SUCCESS → nothing stored when user cancels PIN creation during vault init."""
+
+        mock_settings.get_setting.return_value = None
+        mock_xbmc.show_key_board.return_value = None
+
+        v = Vault()
+        v.set_setting("my_setting", setting_name="My Password")
+
+        mock_settings.set_setting.assert_not_called()
+
+
+class TestVaultGetAfterInit(unittest.TestCase):
+    """get_setting decrypts normally once the vault key is cached."""
+
+    def setUp(self):
+        _reset_vault_key()
+
+    def tearDown(self):
+        _reset_vault_key()
+
+    @patch("resources.lib.vault.AddonSettings")
+    def test_get_setting_returns_none_for_unset_encrypted_value(self, mock_settings):
+        """SUCCESS → None returned when no encrypted value is stored for the key."""
+
+        Vault._Vault__Key = b"a" * 32
+        mock_settings.get_setting.return_value = None
+
+        v = Vault()
+        result = v.get_setting("some_setting")
+
+        self.assertIsNone(result)
+
+
+class TestVaultReset(unittest.TestCase):
+    """reset() clears the cached key and immediately prompts for a new PIN."""
+
+    def setUp(self):
+        _reset_vault_key()
+
+    def tearDown(self):
+        _reset_vault_key()
+
+    @patch("resources.lib.vault.AddonSettings")
+    @patch("resources.lib.vault.XbmcWrapper")
+    def test_reset_confirmed_clears_key_and_triggers_pin_setup(self, mock_xbmc, mock_settings):
+        """SUCCESS → key cleared, howto shown, PIN creation dialogs fired."""
+
+        Vault._Vault__Key = b"a" * 32
+        mock_settings.get_setting.return_value = None
+        mock_settings.get_client_id.return_value = "test-client-id"
+        mock_xbmc.show_yes_no.return_value = True
+        mock_xbmc.show_key_board.side_effect = ["newpin", "newpin"]
+
+        Vault.reset()
+
+        mock_xbmc.show_text.assert_called_once()
+        self.assertGreaterEqual(mock_xbmc.show_key_board.call_count, 2)
+
+    @patch("resources.lib.vault.AddonSettings")
+    @patch("resources.lib.vault.XbmcWrapper")
+    def test_reset_cancelled_preserves_existing_key(self, mock_xbmc, mock_settings):
+        """SUCCESS → no changes when user cancels the reset confirmation."""
+
+        Vault._Vault__Key = b"a" * 32
+        mock_xbmc.show_yes_no.return_value = False
+
+        Vault.reset()
+
+        mock_xbmc.show_text.assert_not_called()
+        self.assertIsNotNone(Vault._Vault__Key)


### PR DESCRIPTION
Vault.__init__ previously triggered the howto dialog and PIN creation flow unconditionally when no application key was present, causing the PIN setup prompt to fire on every channel entry for a fresh install.

Introduce a lazy initializer called only by set_setting and set_channel_setting. The constructor now only decrypts an existing key (prompting for the unlock PIN); it stays silent when no key is stored.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>
Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>